### PR TITLE
Rename merge branch prefix from mq/ to gitea-mq/

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gitea-mq hooks into Gitea's existing **"Merge when checks succeed"** (automerge)
 
 1. User clicks "Merge when checks succeed" on a PR
 2. gitea-mq detects the automerge via polling and enqueues the PR
-3. For the head-of-queue PR, gitea-mq creates a temporary merge branch (`mq/<pr>`) merging the PR into the latest target branch
+3. For the head-of-queue PR, gitea-mq creates a temporary merge branch (`gitea-mq/<pr>`) merging the PR into the latest target branch
 4. CI runs on the merge branch
 5. If all required checks pass → gitea-mq sets its status to `success` → Gitea's automerge performs the actual merge
 6. If checks fail or timeout → gitea-mq cancels automerge and posts a comment explaining why
@@ -57,13 +57,13 @@ but you must create the webhook manually in each repo (event type: `status`, poi
 
 ## CI configuration
 
-Your CI must run on `mq/*` branches. For example, in a Woodpecker/Drone pipeline:
+Your CI must run on `gitea-mq/*` branches. For example, in a Woodpecker/Drone pipeline:
 
 ```yaml
 when:
   branch:
     - main
-    - mq/*
+    - gitea-mq/*
 ```
 
 gitea-mq needs to know which CI checks must pass on the merge branch before it allows a merge. It resolves this in order:

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -317,14 +317,14 @@ func (c *HTTPClient) DeleteBranch(ctx context.Context, owner, repo, name string)
 }
 
 // MergeBranches creates a merge of head into base and pushes it as branch
-// mq/<head-short>. It shells out to git because Gitea has no API to merge
+// gitea-mq/<head-short>. It shells out to git because Gitea has no API to merge
 // two arbitrary refs into a new branch.
 //
 // Steps:
 //  1. Shallow-clone the repo (base branch only)
 //  2. Fetch the head SHA
 //  3. git merge --no-ff the head SHA into base
-//  4. Push the result as mq/<head-short>
+//  4. Push the result as gitea-mq/<head-short>
 //
 // On conflict git merge exits non-zero and we return a MergeConflictError.
 func (c *HTTPClient) MergeBranches(ctx context.Context, owner, repo, base, head, branchName string) (*MergeResult, error) {

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jogman/gitea-mq/internal/gitea"
+	"github.com/jogman/gitea-mq/internal/merge"
 	"github.com/jogman/gitea-mq/internal/monitor"
 	"github.com/jogman/gitea-mq/internal/queue"
 	"github.com/jogman/gitea-mq/internal/store/pg"
@@ -44,7 +45,7 @@ func enqueueTesting(t *testing.T, svc *queue.Service, ctx context.Context, repoI
 		t.Fatal(err)
 	}
 
-	if err := svc.SetMergeBranch(ctx, repoID, prNumber, "mq/42", "mergesha"); err != nil {
+	if err := svc.SetMergeBranch(ctx, repoID, prNumber, merge.BranchName(prNumber), "mergesha"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3,6 +3,7 @@ package queue_test
 import (
 	"testing"
 
+	"github.com/jogman/gitea-mq/internal/merge"
 	"github.com/jogman/gitea-mq/internal/queue"
 	"github.com/jogman/gitea-mq/internal/store/pg"
 	"github.com/jogman/gitea-mq/internal/testutil"
@@ -183,7 +184,9 @@ func TestStateLifecycleAndChecks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := svc.SetMergeBranch(ctx, repoID, 42, "mq/42", "mergesha"); err != nil {
+	wantBranch := merge.BranchName(42)
+
+	if err := svc.SetMergeBranch(ctx, repoID, 42, wantBranch, "mergesha"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -192,8 +195,8 @@ func TestStateLifecycleAndChecks(t *testing.T) {
 		t.Fatalf("expected testing state, got %s", entry.State)
 	}
 
-	if entry.MergeBranchName.String != "mq/42" {
-		t.Fatalf("expected merge branch mq/42, got %s", entry.MergeBranchName.String)
+	if entry.MergeBranchName.String != wantBranch {
+		t.Fatalf("expected merge branch %s, got %s", wantBranch, entry.MergeBranchName.String)
 	}
 
 	// Record check statuses — latest update wins.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jogman/gitea-mq/internal/config"
 	"github.com/jogman/gitea-mq/internal/gitea"
+	"github.com/jogman/gitea-mq/internal/merge"
 	"github.com/jogman/gitea-mq/internal/queue"
 	"github.com/jogman/gitea-mq/internal/registry"
 	"github.com/jogman/gitea-mq/internal/testutil"
@@ -123,7 +124,8 @@ func TestRemoveCleansUpMergeBranchesAndDBEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Enqueue: %v", err)
 	}
-	if err := queueSvc.SetMergeBranch(ctx, m.RepoID, 42, "mq/42", "merge-sha"); err != nil {
+	wantBranch := merge.BranchName(42)
+	if err := queueSvc.SetMergeBranch(ctx, m.RepoID, 42, wantBranch, "merge-sha"); err != nil {
 		t.Fatalf("SetMergeBranch: %v", err)
 	}
 
@@ -135,8 +137,8 @@ func TestRemoveCleansUpMergeBranchesAndDBEntries(t *testing.T) {
 	if len(deleteCalls) != 1 {
 		t.Fatalf("expected 1 DeleteBranch call, got %d", len(deleteCalls))
 	}
-	if deleteCalls[0].Args[2] != "mq/42" {
-		t.Errorf("expected DeleteBranch for mq/42, got %v", deleteCalls[0].Args[2])
+	if deleteCalls[0].Args[2] != wantBranch {
+		t.Errorf("expected DeleteBranch for %s, got %v", wantBranch, deleteCalls[0].Args[2])
 	}
 
 	// Verify DB entries are gone.

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -196,17 +196,17 @@ pkgs.testers.runNixOSTest {
     )
 
     # Wait for the poller to create the merge branch (state=testing).
-    # The merge branch mq/<pr> appears in Gitea when the poller calls
+    # The merge branch gitea-mq/<pr> appears in Gitea when the poller calls
     # StartTesting via git push.
     merge_branch_sha = ""
     machine.wait_until_succeeds(
-        f"curl -sf 'http://localhost:3000/api/v1/repos/testuser/testrepo/branches/mq/{pr_number}' "
+        f"curl -sf 'http://localhost:3000/api/v1/repos/testuser/testrepo/branches/gitea-mq/{pr_number}' "
         f"-H 'Authorization: token {token}' "
         f"| jq -e '.commit.id'",
         timeout=30,
     )
     merge_branch_json = machine.succeed(
-        f"curl -sf 'http://localhost:3000/api/v1/repos/testuser/testrepo/branches/mq/{pr_number}' "
+        f"curl -sf 'http://localhost:3000/api/v1/repos/testuser/testrepo/branches/gitea-mq/{pr_number}' "
         f"-H 'Authorization: token {token}'"
     )
     merge_branch_sha = json.loads(merge_branch_json)["commit"]["id"]

--- a/openspec/changes/archive/2026-02-10-gitea-merge-queue/proposal.md
+++ b/openspec/changes/archive/2026-02-10-gitea-merge-queue/proposal.md
@@ -8,7 +8,7 @@ Gitea lacks a built-in merge queue. Without one, maintainers must manually seria
 - Integrates with Gitea's existing **"Merge when checks succeed"** (automerge) feature — no bot commands needed
 - The service registers `gitea-mq` as a required status check on branch protection; this gates Gitea's automerge
 - Discovers PRs entering automerge state by polling the Gitea API (PR timeline comments of type `pull_scheduled_merge` / `pull_cancel_scheduled_merge`)
-- For the head-of-queue PR, pushes a temporary merge branch (e.g. `mq/<pr-number>`) merging the PR into the latest target branch, and CI runs on that branch
+- For the head-of-queue PR, pushes a temporary merge branch (e.g. `gitea-mq/<pr-number>`) merging the PR into the latest target branch, and CI runs on that branch
 - When all required checks pass on the merge branch, sets the `gitea-mq` commit status to `success` on the PR's head commit — Gitea's automerge then performs the actual merge
 - On failure (check failure, timeout, merge conflict): sets `gitea-mq` to `failure`, cancels the PR's automerge via `DELETE /repos/{owner}/{repo}/pulls/{index}/merge`, and posts a comment explaining why
 - Enforces a configurable check timeout (default: 1 hour) — PRs exceeding it are removed from the queue

--- a/openspec/changes/archive/2026-02-10-gitea-merge-queue/specs/check-monitoring/spec.md
+++ b/openspec/changes/archive/2026-02-10-gitea-merge-queue/specs/check-monitoring/spec.md
@@ -4,7 +4,7 @@
 The system SHALL monitor commit status updates for the temporary merge branch of the head-of-queue PR. The system SHALL aggregate all reported statuses and compare them against the set of required checks.
 
 #### Scenario: Commit status arrives for merge branch
-- **WHEN** a commit status update arrives for the merge branch `mq/42` with context `ci/build` and state `success`
+- **WHEN** a commit status update arrives for the merge branch `gitea-mq/42` with context `ci/build` and state `success`
 - **THEN** the system records this status and evaluates whether all required checks are now satisfied
 
 #### Scenario: Commit status for unrelated branch
@@ -61,13 +61,13 @@ The system SHALL enforce a configurable timeout (default: 1 hour) for required c
 The system SHALL always use the most recent status for each check context. If a check transitions from `failure` back to `pending` and then to `success` (e.g. CI retry), the final `success` state SHALL be used.
 
 #### Scenario: Check retried after failure
-- **WHEN** check `ci/build` reports `failure` on merge branch `mq/42`
+- **WHEN** check `ci/build` reports `failure` on merge branch `gitea-mq/42`
 - **AND** then `ci/build` reports `pending` (retry started)
 - **AND** then `ci/build` reports `success`
 - **THEN** the system treats `ci/build` as `success`
 
 #### Scenario: Check goes from success to failure
-- **WHEN** check `ci/build` reports `success` on merge branch `mq/42`
+- **WHEN** check `ci/build` reports `success` on merge branch `gitea-mq/42`
 - **AND** then `ci/build` reports `failure` (re-run failed)
 - **THEN** the system treats `ci/build` as `failure`
 
@@ -75,7 +75,7 @@ The system SHALL always use the most recent status for each check context. If a 
 The system SHALL remove the head-of-queue PR when any required check reports a terminal failure state (`failure` or `error`) on the merge branch.
 
 #### Scenario: Required check reports failure
-- **WHEN** check `ci/build` reports `failure` on merge branch `mq/42`
+- **WHEN** check `ci/build` reports `failure` on merge branch `gitea-mq/42`
 - **THEN** the system removes PR #42 from the queue
 - **AND** cancels automerge on PR #42
 - **AND** posts a comment on PR #42 explaining which check failed

--- a/openspec/changes/archive/2026-02-10-gitea-merge-queue/specs/queue-management/spec.md
+++ b/openspec/changes/archive/2026-02-10-gitea-merge-queue/specs/queue-management/spec.md
@@ -22,7 +22,7 @@ The system SHALL remove a PR from its repository's merge queue when automerge is
 #### Scenario: Dequeue the head-of-queue PR
 - **WHEN** automerge is cancelled for PR #42 which is head-of-queue and being tested
 - **THEN** PR #42 is removed from the queue
-- **AND** the temporary merge branch `mq/42` is deleted
+- **AND** the temporary merge branch `gitea-mq/42` is deleted
 - **AND** the system advances to the next PR in the queue
 
 ### Requirement: FIFO ordering
@@ -42,16 +42,16 @@ The system SHALL test at most one PR per repository at any given time. The next 
 - **THEN** PR #20 remains in `queued` state and is not tested until PR #10 completes
 
 ### Requirement: Temporary merge branch for testing
-The system SHALL create a temporary merge branch by merging the PR's head into the latest target branch. The branch SHALL be named `mq/<pr-number>`. CI runs on this branch. The system SHALL delete the merge branch after the PR is merged, removed, or fails.
+The system SHALL create a temporary merge branch by merging the PR's head into the latest target branch. The branch SHALL be named `gitea-mq/<pr-number>`. CI runs on this branch. The system SHALL delete the merge branch after the PR is merged, removed, or fails.
 
 #### Scenario: Create merge branch for head-of-queue PR
 - **WHEN** PR #42 targeting `main` becomes head-of-queue in repo `org/app`
 - **THEN** the system fetches the latest `main` ref
-- **AND** creates branch `mq/42` containing the merge of PR #42's head into `main`
+- **AND** creates branch `gitea-mq/42` containing the merge of PR #42's head into `main`
 - **AND** the system updates the `gitea-mq` commit status to `pending` with description "Testing merge result"
 
 #### Scenario: Merge branch deleted externally during testing
-- **WHEN** the merge branch `mq/42` is deleted by someone while CI is running
+- **WHEN** the merge branch `gitea-mq/42` is deleted by someone while CI is running
 - **THEN** the system treats this as a failure
 - **AND** removes PR #42 from the queue
 - **AND** cancels automerge on PR #42
@@ -71,9 +71,9 @@ The system SHALL create a temporary merge branch by merging the PR's head into t
 The system SHALL set the `gitea-mq` commit status to `success` on the PR's head commit when all required checks pass on the merge branch. The PR SHALL remain as head-of-queue until the poller confirms Gitea has actually merged it. The system SHALL NOT advance to the next PR until the merge is confirmed.
 
 #### Scenario: All required checks pass on merge branch
-- **WHEN** all required checks for the merge branch `mq/42` report `success`
+- **WHEN** all required checks for the merge branch `gitea-mq/42` report `success`
 - **THEN** the system posts a `gitea-mq` commit status of `success` with description "Merge queue passed"
-- **AND** deletes the temporary merge branch `mq/42`
+- **AND** deletes the temporary merge branch `gitea-mq/42`
 - **AND** the PR remains head-of-queue in `success` state, waiting for Gitea's automerge to complete
 
 #### Scenario: Gitea's automerge succeeds
@@ -109,7 +109,7 @@ The system SHALL remove a PR from the merge queue when new commits are pushed to
 - **WHEN** PR #42 is head-of-queue and being tested
 - **AND** new commits are pushed to PR #42's head branch (head SHA changes)
 - **THEN** the system removes PR #42 from the queue
-- **AND** deletes the temporary merge branch `mq/42`
+- **AND** deletes the temporary merge branch `gitea-mq/42`
 - **AND** cancels automerge on PR #42
 - **AND** posts a comment explaining the PR was removed due to new commits
 - **AND** sets `gitea-mq` commit status to `error` with description "New commits pushed"

--- a/openspec/changes/archive/2026-02-10-gitea-merge-queue/specs/webhook-receiver/spec.md
+++ b/openspec/changes/archive/2026-02-10-gitea-merge-queue/specs/webhook-receiver/spec.md
@@ -40,7 +40,7 @@ The system SHALL ignore commit status webhook events where the context is `gitea
 The system SHALL handle duplicate webhook deliveries idempotently. Processing the same event multiple times SHALL have no additional effect beyond the first processing.
 
 #### Scenario: Duplicate status event
-- **WHEN** a commit status event for `ci/build` = `success` on merge branch `mq/42` is delivered twice
+- **WHEN** a commit status event for `ci/build` = `success` on merge branch `gitea-mq/42` is delivered twice
 - **THEN** the second delivery has no additional effect — the check is already recorded as `success`
 
 ### Requirement: Route commit_status events

--- a/openspec/changes/archive/2026-02-10-gitea-merge-queue/tasks.md
+++ b/openspec/changes/archive/2026-02-10-gitea-merge-queue/tasks.md
@@ -48,7 +48,7 @@ NOTE: Covered by section 2 — queue.Service operates directly on PostgreSQL via
 - [x] 4.7 Implement HTTP `GiteaClient`: `CancelAutoMerge` (`DELETE /repos/{owner}/{repo}/pulls/{index}/merge`)
 - [x] 4.8 Implement HTTP `GiteaClient`: `GetBranchProtection` (extract `status_check_contexts`, filter out `gitea-mq`)
 - [x] 4.9 Implement HTTP `GiteaClient`: `CreateBranch`, `DeleteBranch`
-- [x] 4.10 Spike: determine how to create merge branch via Gitea API (merge two refs → push as `mq/<pr>`) and implement `MergeBranches`
+- [x] 4.10 Spike: determine how to create merge branch via Gitea API (merge two refs → push as `gitea-mq/<pr>`) and implement `MergeBranches`
 - [x] 4.11 Implement HTTP `GiteaClient`: `ListBranchProtections`, `EditBranchProtection` (for auto-setup)
 - [x] 4.12 Implement HTTP `GiteaClient`: `ListWebhooks`, `CreateWebhook` (for auto-setup)
 
@@ -108,7 +108,7 @@ NOTE: Covered by section 2 — queue.Service operates directly on PostgreSQL via
 - [x] 8.2 Implement `queue.StartTesting` (create merge branch, update state)
 - [x] 8.3 Write tests for merge branch cleanup: delete branch on success/failure/cancel
 - [x] 8.4 Implement `queue.CleanupMergeBranch`
-- [x] 8.5 Write tests for stale merge branch detection on startup: orphaned `mq/*` branches → cleaned up
+- [x] 8.5 Write tests for stale merge branch detection on startup: orphaned `gitea-mq/*` branches → cleaned up
 - [x] 8.6 Implement startup cleanup scan
 
 ## 9. Web Dashboard

--- a/openspec/specs/check-monitoring/spec.md
+++ b/openspec/specs/check-monitoring/spec.md
@@ -4,7 +4,7 @@
 The system SHALL monitor commit status updates for the temporary merge branch of the head-of-queue PR. The system SHALL aggregate all reported statuses and compare them against the set of required checks.
 
 #### Scenario: Commit status arrives for merge branch
-- **WHEN** a commit status update arrives for the merge branch `mq/42` with context `ci/build` and state `success`
+- **WHEN** a commit status update arrives for the merge branch `gitea-mq/42` with context `ci/build` and state `success`
 - **THEN** the system records this status and evaluates whether all required checks are now satisfied
 
 #### Scenario: Commit status for unrelated branch
@@ -61,13 +61,13 @@ The system SHALL enforce a configurable timeout (default: 1 hour) for required c
 The system SHALL always use the most recent status for each check context. If a check transitions from `failure` back to `pending` and then to `success` (e.g. CI retry), the final `success` state SHALL be used.
 
 #### Scenario: Check retried after failure
-- **WHEN** check `ci/build` reports `failure` on merge branch `mq/42`
+- **WHEN** check `ci/build` reports `failure` on merge branch `gitea-mq/42`
 - **AND** then `ci/build` reports `pending` (retry started)
 - **AND** then `ci/build` reports `success`
 - **THEN** the system treats `ci/build` as `success`
 
 #### Scenario: Check goes from success to failure
-- **WHEN** check `ci/build` reports `success` on merge branch `mq/42`
+- **WHEN** check `ci/build` reports `success` on merge branch `gitea-mq/42`
 - **AND** then `ci/build` reports `failure` (re-run failed)
 - **THEN** the system treats `ci/build` as `failure`
 
@@ -75,7 +75,7 @@ The system SHALL always use the most recent status for each check context. If a 
 The system SHALL remove the head-of-queue PR when any required check reports a terminal failure state (`failure` or `error`) on the merge branch.
 
 #### Scenario: Required check reports failure
-- **WHEN** check `ci/build` reports `failure` on merge branch `mq/42`
+- **WHEN** check `ci/build` reports `failure` on merge branch `gitea-mq/42`
 - **THEN** the system removes PR #42 from the queue
 - **AND** cancels automerge on PR #42
 - **AND** posts a comment on PR #42 explaining which check failed

--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -22,7 +22,7 @@ The system SHALL remove a PR from its repository's merge queue when automerge is
 #### Scenario: Dequeue the head-of-queue PR
 - **WHEN** automerge is cancelled for PR #42 which is head-of-queue and being tested
 - **THEN** PR #42 is removed from the queue
-- **AND** the temporary merge branch `mq/42` is deleted
+- **AND** the temporary merge branch `gitea-mq/42` is deleted
 - **AND** the system advances to the next PR in the queue
 
 ### Requirement: FIFO ordering
@@ -42,16 +42,16 @@ The system SHALL test at most one PR per repository at any given time. The next 
 - **THEN** PR #20 remains in `queued` state and is not tested until PR #10 completes
 
 ### Requirement: Temporary merge branch for testing
-The system SHALL create a temporary merge branch by merging the PR's head into the latest target branch. The branch SHALL be named `mq/<pr-number>`. CI runs on this branch. The system SHALL delete the merge branch after the PR is merged, removed, or fails.
+The system SHALL create a temporary merge branch by merging the PR's head into the latest target branch. The branch SHALL be named `gitea-mq/<pr-number>`. CI runs on this branch. The system SHALL delete the merge branch after the PR is merged, removed, or fails.
 
 #### Scenario: Create merge branch for head-of-queue PR
 - **WHEN** PR #42 targeting `main` becomes head-of-queue in repo `org/app`
 - **THEN** the system fetches the latest `main` ref
-- **AND** creates branch `mq/42` containing the merge of PR #42's head into `main`
+- **AND** creates branch `gitea-mq/42` containing the merge of PR #42's head into `main`
 - **AND** the system updates the `gitea-mq` commit status to `pending` with description "Testing merge result"
 
 #### Scenario: Merge branch deleted externally during testing
-- **WHEN** the merge branch `mq/42` is deleted by someone while CI is running
+- **WHEN** the merge branch `gitea-mq/42` is deleted by someone while CI is running
 - **THEN** the system treats this as a failure
 - **AND** removes PR #42 from the queue
 - **AND** cancels automerge on PR #42
@@ -71,9 +71,9 @@ The system SHALL create a temporary merge branch by merging the PR's head into t
 The system SHALL set the `gitea-mq` commit status to `success` on the PR's head commit when all required checks pass on the merge branch. The PR SHALL remain as head-of-queue until the poller confirms Gitea has actually merged it. The system SHALL NOT advance to the next PR until the merge is confirmed.
 
 #### Scenario: All required checks pass on merge branch
-- **WHEN** all required checks for the merge branch `mq/42` report `success`
+- **WHEN** all required checks for the merge branch `gitea-mq/42` report `success`
 - **THEN** the system posts a `gitea-mq` commit status of `success` with description "Merge queue passed"
-- **AND** deletes the temporary merge branch `mq/42`
+- **AND** deletes the temporary merge branch `gitea-mq/42`
 - **AND** the PR remains head-of-queue in `success` state, waiting for Gitea's automerge to complete
 
 #### Scenario: Gitea's automerge succeeds
@@ -109,7 +109,7 @@ The system SHALL remove a PR from the merge queue when new commits are pushed to
 - **WHEN** PR #42 is head-of-queue and being tested
 - **AND** new commits are pushed to PR #42's head branch (head SHA changes)
 - **THEN** the system removes PR #42 from the queue
-- **AND** deletes the temporary merge branch `mq/42`
+- **AND** deletes the temporary merge branch `gitea-mq/42`
 - **AND** cancels automerge on PR #42
 - **AND** posts a comment explaining the PR was removed due to new commits
 - **AND** sets `gitea-mq` commit status to `error` with description "New commits pushed"

--- a/openspec/specs/webhook-receiver/spec.md
+++ b/openspec/specs/webhook-receiver/spec.md
@@ -40,7 +40,7 @@ The system SHALL ignore commit status webhook events where the context is `gitea
 The system SHALL handle duplicate webhook deliveries idempotently. Processing the same event multiple times SHALL have no additional effect beyond the first processing.
 
 #### Scenario: Duplicate status event
-- **WHEN** a commit status event for `ci/build` = `success` on merge branch `mq/42` is delivered twice
+- **WHEN** a commit status event for `ci/build` = `success` on merge branch `gitea-mq/42` is delivered twice
 - **THEN** the second delivery has no additional effect — the check is already recorded as `success`
 
 ### Requirement: Route commit_status events


### PR DESCRIPTION
The generic "mq/" prefix could easily clash with other tools or user-created branches. Using "gitea-mq/" makes ownership clear and avoids ambiguity in repositories that may have other merge queue integrations.

Extract the prefix into a BranchPrefix constant and BranchName helper so future renames only require changing one line.