### PR TITLE
webhook: treat 'warning' commit status as success

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -134,7 +134,7 @@ func (e *statusEvent) validate() error {
 
 func mapState(s string) pg.CheckState {
 	switch s {
-	case "success":
+	case "success", "warning":
 		return pg.CheckStateSuccess
 	case "failure":
 		return pg.CheckStateFailure


### PR DESCRIPTION
Gitea's commit status API supports a 'warning' state which indicates a check completed with warnings (e.g. buildbot/nix-eval). Previously this fell through to the default case and was mapped to 'pending', causing gitea-mq to wait indefinitely for a check that already finished.

Map 'warning' to success since it represents a completed (non-failing) check.