### PR TITLE
web: show all required checks as pending before CI reports

### DIFF
--- a/cmd/gitea-mq/main.go
+++ b/cmd/gitea-mq/main.go
@@ -136,6 +136,7 @@ func run() error {
 		Queue:           queueSvc,
 		Repos:           reg,
 		Gitea:           giteaClient,
+		FallbackChecks:  cfg.RequiredChecks,
 		RefreshInterval: int(cfg.RefreshInterval.Seconds()),
 	}
 	dashMux := web.NewMux(webDeps)


### PR DESCRIPTION
When a PR enters testing, the dashboard only showed checks that CI had already reported back. If CI was slow to start, the checks section appeared empty — giving no indication of what the queue was waiting for.

Resolve the required checks list from branch protection (or fallback config) and merge it with recorded statuses. Unreported required checks now appear immediately as pending, so users can see at a glance which checks are still outstanding.