### PR TITLE
web: link PR detail page to CI status on Gitea

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -202,9 +202,9 @@ func removeFromQueue(ctx context.Context, deps *Deps, entry *pg.QueueEntry, stat
 // ProcessCheckStatus is the main entry point called when a webhook delivers
 // a commit status event for a merge branch. It records the status, evaluates
 // checks, and triggers success/failure handling as appropriate.
-func ProcessCheckStatus(ctx context.Context, deps *Deps, entry *pg.QueueEntry, checkContext string, checkState pg.CheckState) error {
+func ProcessCheckStatus(ctx context.Context, deps *Deps, entry *pg.QueueEntry, checkContext string, checkState pg.CheckState, targetURL string) error {
 	// Record the check status (latest wins — upsert).
-	if err := deps.Queue.SaveCheckStatus(ctx, entry.ID, checkContext, checkState); err != nil {
+	if err := deps.Queue.SaveCheckStatus(ctx, entry.ID, checkContext, checkState, targetURL); err != nil {
 		return fmt.Errorf("save check status for PR #%d: %w", entry.PrNumber, err)
 	}
 

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -68,7 +68,7 @@ func TestProcessCheckStatus_AllPass_TriggersSuccess(t *testing.T) {
 
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
-	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess); err != nil {
+	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -101,7 +101,7 @@ func TestProcessCheckStatus_Failure_CancelsAndAdvances(t *testing.T) {
 
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
-	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateFailure); err != nil {
+	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateFailure, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -134,7 +134,7 @@ func TestProcessCheckStatus_Partial_StaysWaiting(t *testing.T) {
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
 	// Only ci/build reported — ci/lint still pending.
-	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess); err != nil {
+	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -160,7 +160,7 @@ func TestProcessCheckStatus_RetrySuccess(t *testing.T) {
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
 	// First: failure.
-	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateFailure); err != nil {
+	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateFailure, ""); err != nil {
 		t.Fatal(err)
 	}
 	// This triggers failure handling — reset for the retry test.
@@ -172,8 +172,8 @@ func TestProcessCheckStatus_RetrySuccess(t *testing.T) {
 	entry, _ = svc.GetEntry(ctx, repoID, 42)
 
 	// Record failure, then overwrite with success (simulating retry).
-	_ = svc.SaveCheckStatus(ctx, entry.ID, "ci/build", pg.CheckStateFailure)
-	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess); err != nil {
+	_ = svc.SaveCheckStatus(ctx, entry.ID, "ci/build", pg.CheckStateFailure, "")
+	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -284,11 +284,12 @@ func (s *Service) GetEntry(ctx context.Context, repoID, prNumber int64) (*pg.Que
 }
 
 // SaveCheckStatus records or updates a check status for an entry.
-func (s *Service) SaveCheckStatus(ctx context.Context, entryID int64, checkContext string, state pg.CheckState) error {
+func (s *Service) SaveCheckStatus(ctx context.Context, entryID int64, checkContext string, state pg.CheckState, targetURL string) error {
 	return s.queries().SaveCheckStatus(ctx, pg.SaveCheckStatusParams{
 		QueueEntryID: entryID,
 		Context:      checkContext,
 		State:        state,
+		TargetUrl:    targetURL,
 	})
 }
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -200,17 +200,21 @@ func TestStateLifecycleAndChecks(t *testing.T) {
 	}
 
 	// Record check statuses — latest update wins.
-	if err := svc.SaveCheckStatus(ctx, enq.Entry.ID, "ci/build", pg.CheckStatePending); err != nil {
+	if err := svc.SaveCheckStatus(ctx, enq.Entry.ID, "ci/build", pg.CheckStatePending, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := svc.SaveCheckStatus(ctx, enq.Entry.ID, "ci/build", pg.CheckStateSuccess); err != nil {
+	if err := svc.SaveCheckStatus(ctx, enq.Entry.ID, "ci/build", pg.CheckStateSuccess, "https://ci.example.com/build/1"); err != nil {
 		t.Fatal(err)
 	}
 
 	checks, _ := svc.GetCheckStatuses(ctx, enq.Entry.ID)
 	if len(checks) != 1 || checks[0].State != pg.CheckStateSuccess {
 		t.Fatalf("expected 1 check with state success, got %v", checks)
+	}
+	// Upsert must also update target_url.
+	if checks[0].TargetUrl != "https://ci.example.com/build/1" {
+		t.Fatalf("expected target_url from latest upsert, got %q", checks[0].TargetUrl)
 	}
 }
 

--- a/internal/store/pg/migrations/002_check_status_target_url.sql
+++ b/internal/store/pg/migrations/002_check_status_target_url.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE check_statuses ADD COLUMN target_url TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE check_statuses DROP COLUMN target_url;

--- a/internal/store/pg/models.go
+++ b/internal/store/pg/models.go
@@ -106,6 +106,7 @@ type CheckStatus struct {
 	Context      string             `json:"context"`
 	State        CheckState         `json:"state"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TargetUrl    string             `json:"target_url"`
 }
 
 type QueueEntry struct {

--- a/internal/store/pg/query.sql
+++ b/internal/store/pg/query.sql
@@ -46,10 +46,10 @@ SET error_message = $3
 WHERE repo_id = $1 AND pr_number = $2;
 
 -- name: SaveCheckStatus :exec
-INSERT INTO check_statuses (queue_entry_id, context, state)
-VALUES ($1, $2, $3)
+INSERT INTO check_statuses (queue_entry_id, context, state, target_url)
+VALUES ($1, $2, $3, $4)
 ON CONFLICT (queue_entry_id, context) DO UPDATE
-SET state = EXCLUDED.state, updated_at = NOW();
+SET state = EXCLUDED.state, target_url = EXCLUDED.target_url, updated_at = NOW();
 
 -- name: GetCheckStatuses :many
 SELECT * FROM check_statuses

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -126,7 +126,8 @@ type PRDetailData struct {
 	EnqueuedAt      time.Time
 	CheckStatuses   []pg.CheckStatus
 	InQueue         bool
-	RefreshInterval int // seconds
+	MergeBranchURL  string // link to the merge branch on Gitea
+	RefreshInterval int    // seconds
 }
 
 // RepoLister abstracts how the dashboard gets the current managed repo set.
@@ -366,6 +367,14 @@ func servePRDetail(w http.ResponseWriter, r *http.Request, deps *Deps, owner, na
 			data.Title = pr.Title
 			if pr.User != nil {
 				data.Author = pr.User.Login
+			}
+			// Construct merge branch URL from the PR's HTML URL.
+			// PR URL: https://gitea.example.com/owner/repo/pulls/42
+			// Branch URL: https://gitea.example.com/owner/repo/src/branch/{name}
+			if entry.MergeBranchName.Valid && entry.MergeBranchName.String != "" && pr.HTMLURL != "" {
+				if idx := strings.Index(pr.HTMLURL, "/pulls/"); idx >= 0 {
+					data.MergeBranchURL = pr.HTMLURL[:idx] + "/src/branch/" + entry.MergeBranchName.String
+				}
 			}
 		}
 	}

--- a/internal/web/templates/pr.html
+++ b/internal/web/templates/pr.html
@@ -22,6 +22,7 @@
                 <tr><th>State</th><td><span class="state state-{{.State}}">{{.State}}</span></td></tr>
                 <tr><th>Position</th><td>#{{.Position}}</td></tr>
                 <tr><th>Enqueued</th><td>{{relativeTime .EnqueuedAt}}</td></tr>
+                {{if .MergeBranchURL}}<tr><th>Merge Branch</th><td><a href="{{.MergeBranchURL}}">view on Gitea ↗</a></td></tr>{{end}}
             </tbody>
         </table>
     </div>
@@ -40,7 +41,7 @@
                 {{range .CheckStatuses}}
                 <tr>
                     <td class="check-icon">{{checkIcon .State}}</td>
-                    <td>{{.Context}}</td>
+                    <td>{{if .TargetUrl}}<a href="{{.TargetUrl}}">{{.Context}} ↗</a>{{else}}{{.Context}}{{end}}</td>
                 </tr>
                 {{end}}
             </tbody>

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -96,7 +96,7 @@ func Handler(secret string, repos RepoLookup, queueSvc *queue.Service) http.Hand
 
 		checkState := mapState(event.State)
 
-		if err := monitor.ProcessCheckStatus(r.Context(), rm.Deps, entry, event.Context, checkState); err != nil {
+		if err := monitor.ProcessCheckStatus(r.Context(), rm.Deps, entry, event.Context, checkState, event.TargetURL); err != nil {
 			slog.Error("failed to process check status", "pr", entry.PrNumber, "error", err)
 			// Still return 200 — Gitea will retry on non-2xx, which could
 			// cause duplicate processing.
@@ -111,6 +111,7 @@ type statusEvent struct {
 	SHA        string `json:"sha"`
 	Context    string `json:"context"`
 	State      string `json:"state"` // "pending", "success", "failure", "error"
+	TargetURL  string `json:"target_url"`
 	Repository struct {
 		FullName string `json:"full_name"` // "owner/repo"
 	} `json:"repository"`


### PR DESCRIPTION
When a PR is head-of-queue and testing, users had no way to navigate from the dashboard to the actual CI runs. They had to manually find the merge branch on Gitea or guess the CI system URL.

Add a "Merge Branch" row that links to the merge branch page on Gitea, derived from the PR's HTML URL. This gives immediate access to the combined commit status overview.

Make individual check names clickable when CI systems report a target_url (e.g. linking to a Buildbot or Actions run page). This requires storing target_url from the commit_status webhook payload, so add a goose migration for the new column and thread the value through webhook -> monitor -> queue -> template.