### PR TITLE
web: link PR heading to Gitea

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -126,6 +126,7 @@ type PRDetailData struct {
 	EnqueuedAt      time.Time
 	CheckStatuses   []pg.CheckStatus
 	InQueue         bool
+	PRURL           string // link to the PR on Gitea
 	MergeBranchURL  string // link to the merge branch on Gitea
 	RefreshInterval int    // seconds
 }
@@ -365,6 +366,7 @@ func servePRDetail(w http.ResponseWriter, r *http.Request, deps *Deps, owner, na
 			slog.Warn("failed to fetch PR from Gitea", "pr", prNumber, "error", err)
 		} else {
 			data.Title = pr.Title
+			data.PRURL = pr.HTMLURL
 			if pr.User != nil {
 				data.Author = pr.User.Login
 			}

--- a/internal/web/templates/pr.html
+++ b/internal/web/templates/pr.html
@@ -14,7 +14,7 @@
     <h1>PR #{{.PrNumber}}</h1>
     <p class="empty">PR #{{.PrNumber}} is not in the merge queue.</p>
     {{else}}
-    <h1>PR #{{.PrNumber}}: {{.Title}}</h1>
+    <h1>{{if .PRURL}}<a href="{{.PRURL}}">PR #{{.PrNumber}}</a>{{else}}PR #{{.PrNumber}}{{end}}: {{.Title}}</h1>
     <div class="section">
         <table>
             <tbody>

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -219,6 +219,10 @@ func TestPRDetailHeadOfQueueTesting(t *testing.T) {
 	if !strings.Contains(body, "Fix login bug") {
 		t.Error("expected PR title")
 	}
+	// PR number in h1 should link to Gitea.
+	if !strings.Contains(body, `<a href="https://gitea.example.com/org/app/pulls/42">PR #42</a>`) {
+		t.Errorf("expected PR link in heading, got:\n%s", body)
+	}
 	if !strings.Contains(body, "alice") {
 		t.Error("expected PR author")
 	}


### PR DESCRIPTION
Users viewing a PR in the dashboard had to manually navigate to Gitea to see the full PR discussion. Make the PR number in the h1 a direct link to the PR page on Gitea, derived from the HTMLURL returned by the API. Falls back to plain text when the API is unavailable.