### PR TITLE
module: hide gitea-mq/* branches from git fetch via uploadpack.hideRefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ On startup, gitea-mq automatically configures each managed repository:
 `GITEA_MQ_EXTERNAL_URL` is the externally-reachable URL of gitea-mq (e.g. `https://mq.example.com`), **not** the Gitea URL.
 It is used for webhook auto-setup and as the target URL in commit statuses (linking to the dashboard).
 
+## Hiding merge branches from git clients
+
+gitea-mq creates temporary branches under `gitea-mq/*` for CI testing. By default, these branches are visible to git clients and will be fetched by `git fetch`. To prevent this, you can configure Gitea's git to hide them from the ref advertisement.
+
+**NixOS**: When `services.gitea` is enabled on the same host, the NixOS module automatically configures `uploadpack.hideRefs` for you. To disable this, set:
+
+```nix
+services.gitea-mq.hideRefFromClients = false;
+```
+
+**Non-NixOS**: Run the following as the Gitea system user (the user that owns the Gitea data directory):
+
+```bash
+git config --global uploadpack.hideRefs refs/heads/gitea-mq/
+```
+
+This hides the branches from `git fetch` and `git ls-remote` but does not affect the Gitea web UI, API, or webhook-driven CI. CI systems that need to check out merge branches can still fetch them with an explicit refspec (e.g., `git fetch origin gitea-mq/123`).
+
 ## CI configuration
 
 Your CI must run on `gitea-mq/*` branches. For example, in a Woodpecker/Drone pipeline:

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -264,6 +264,14 @@ pkgs.testers.runNixOSTest {
         timeout=30,
     )
 
+    # --- Verify uploadpack.hideRefs is configured ---
+    machine.succeed(
+        "su -l gitea -s /bin/sh -c '"
+        "export HOME=/var/lib/gitea GIT_CONFIG_NOSYSTEM=1; "
+        "${pkgs.git}/bin/git config --global --get uploadpack.hideRefs | grep -q refs/heads/gitea-mq/"
+        "'"
+    )
+
     # --- Topic-based discovery test ---
     # Create a second repo with the merge-queue topic and verify it gets discovered.
     machine.succeed(


### PR DESCRIPTION
Git clients fetch all refs under refs/heads/ by default, which means temporary merge queue branches (gitea-mq/*) pollute local repos. GitHub solves this server-side with uploadpack.hideRefs, but Gitea has no built-in support for it.

Configure uploadpack.hideRefs in Gitea's global git config via an ExecStartPre hook on the gitea service. This is idempotent and survives Gitea restarts (Gitea's syncGitConfig doesn't touch this key). Enabled automatically when services.gitea is on the same host.

For non-NixOS deployments, document the manual git config command.