### PR TITLE
webhook: forward statuses to original PRs

### DIFF
--- a/internal/integration/e2e_test.go
+++ b/internal/integration/e2e_test.go
@@ -195,6 +195,7 @@ func TestFullMergeQueueFlow(t *testing.T) {
 		"sha": %q,
 		"context": "ci/build",
 		"state": "success",
+		"description": "build passed",
 		"repository": {"full_name": %q}
 	}`, mergeBranchSHA, repoKey)
 
@@ -209,6 +210,28 @@ func TestFullMergeQueueFlow(t *testing.T) {
 	webhookHandler.ServeHTTP(recorder, webhookReq)
 	if recorder.statusCode != http.StatusOK {
 		t.Fatalf("webhook returned %d", recorder.statusCode)
+	}
+
+	// --- Step 3b: Verify mirrored status gitea-mq/ci/build on PR head ---
+	_, mirrorStatusBody := api.Do(t, "GET", "/repos/testuser/"+repoName+"/statuses/"+pr.Head.SHA, "")
+
+	var mirrorStatuses []struct {
+		Context     string `json:"context"`
+		Status      string `json:"status"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(mirrorStatusBody, &mirrorStatuses); err != nil {
+		t.Fatalf("unmarshal mirror statuses: %v", err)
+	}
+
+	foundMirror := false
+	for _, s := range mirrorStatuses {
+		if s.Context == "gitea-mq/ci/build" && s.Status == "success" && s.Description == "build passed" {
+			foundMirror = true
+		}
+	}
+	if !foundMirror {
+		t.Fatalf("expected gitea-mq/ci/build=success with description 'build passed' mirrored on PR head, got: %s", mirrorStatusBody)
 	}
 
 	// --- Step 4: Verify monitor set gitea-mq=success on PR head ---

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -16,6 +16,11 @@ import (
 // BranchPrefix is the prefix for temporary merge branches created by gitea-mq.
 const BranchPrefix = "gitea-mq/"
 
+// StaleMirrorDescription is the description set on gitea-mq/* mirrored statuses
+// when they are cleared. Gitea doesn't support deleting commit statuses, so we
+// overwrite them with this description instead.
+const StaleMirrorDescription = "From a previous merge queue attempt"
+
 // BranchName returns the merge branch name for a given PR number.
 func BranchName(prNumber int64) string {
 	return fmt.Sprintf("%s%d", BranchPrefix, prNumber)
@@ -81,6 +86,10 @@ func StartTesting(ctx context.Context, giteaClient gitea.Client, svc *queue.Serv
 		return nil, fmt.Errorf("update state to testing for PR #%d: %w", entry.PrNumber, err)
 	}
 
+	// Clear stale gitea-mq/* mirrored statuses from a previous merge queue
+	// attempt so they don't show outdated results while new CI runs.
+	clearStaleMirroredStatuses(ctx, giteaClient, owner, repo, entry.PrHeadSha)
+
 	// Update the pending status to indicate testing.
 	_ = giteaClient.CreateCommitStatus(ctx, owner, repo, entry.PrHeadSha,
 		gitea.MQStatus("pending", "Testing merge result", targetURL))
@@ -91,6 +100,28 @@ func StartTesting(ctx context.Context, giteaClient gitea.Client, svc *queue.Serv
 		MergeBranchName: branchName,
 		MergeBranchSHA:  mergeResult.SHA,
 	}, nil
+}
+
+// clearStaleMirroredStatuses resets any gitea-mq/* mirrored statuses on the
+// PR head to pending. These are left over from a previous merge queue attempt
+// and would otherwise show stale success/failure until new CI results arrive.
+func clearStaleMirroredStatuses(ctx context.Context, giteaClient gitea.Client, owner, repo, sha string) {
+	combined, err := giteaClient.GetCombinedCommitStatus(ctx, owner, repo, sha)
+	if err != nil {
+		slog.Warn("failed to fetch commit statuses for stale cleanup", "sha", sha, "error", err)
+		return
+	}
+
+	for _, s := range combined.Statuses {
+		if !strings.HasPrefix(s.Context, BranchPrefix) {
+			continue
+		}
+		_ = giteaClient.CreateCommitStatus(ctx, owner, repo, sha, gitea.CommitStatus{
+			Context:     s.Context,
+			State:       "pending",
+			Description: StaleMirrorDescription,
+		})
+	}
 }
 
 // CleanupMergeBranch deletes a merge branch if it exists.

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -126,6 +126,135 @@ func TestStartTesting_Conflict(t *testing.T) {
 	}
 }
 
+// StartTesting clears stale gitea-mq/* mirrored statuses from a previous merge
+// queue attempt so they don't show outdated results while new CI runs.
+func TestStartTesting_ClearsStaleStatuses(t *testing.T) {
+	mock, svc, ctx, repoID := setup(t)
+
+	mock.MergeBranchesFn = func(_ context.Context, _, _, _, _, _ string) (*gitea.MergeResult, error) {
+		return &gitea.MergeResult{SHA: "mergesha456"}, nil
+	}
+
+	// Simulate stale gitea-mq/* statuses from a previous merge queue attempt.
+	mock.GetCombinedCommitStatusFn = func(_ context.Context, _, _, ref string) (*gitea.CombinedStatus, error) {
+		return &gitea.CombinedStatus{
+			SHA:   ref,
+			State: "failure",
+			Statuses: []gitea.CommitStatusResult{
+				{Context: "gitea-mq/ci/build", Status: "success"},
+				{Context: "gitea-mq/ci/lint", Status: "failure"},
+				{Context: "gitea-mq/ci/test", Status: "pending", Description: "test running"}, // already pending with different desc
+				{Context: "gitea-mq", Status: "failure"},                                      // overwritten by StartTesting's own status
+				{Context: "ci/build", Status: "success"},                                      // non-MQ status, should be left alone
+			},
+		}, nil
+	}
+
+	if _, err := svc.Enqueue(ctx, repoID, 42, "prsha", "main"); err != nil {
+		t.Fatal(err)
+	}
+	entry, _ := svc.GetEntry(ctx, repoID, 42)
+
+	result, err := merge.StartTesting(ctx, mock, svc, "org", "app", repoID, entry, "https://mq.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed {
+		t.Fatal("expected PR to enter testing, not be removed")
+	}
+
+	statusCalls := mock.CallsTo("CreateCommitStatus")
+
+	clearedContexts := make(map[string]bool)
+	var testingStatusPosted bool
+	for _, call := range statusCalls {
+		sha := call.Args[2].(string)
+		status := call.Args[3].(gitea.CommitStatus)
+
+		if sha != "prsha" {
+			t.Fatalf("expected status on prsha, got %s", sha)
+		}
+
+		if status.Context == "gitea-mq" && status.Description == "Testing merge result" {
+			testingStatusPosted = true
+			continue
+		}
+
+		if status.State == "pending" && status.Description == "From a previous merge queue attempt" {
+			clearedContexts[status.Context] = true
+		}
+	}
+
+	if !testingStatusPosted {
+		t.Fatal("expected 'Testing merge result' status to be posted")
+	}
+	if !clearedContexts["gitea-mq/ci/build"] {
+		t.Fatal("expected stale gitea-mq/ci/build to be reset to pending")
+	}
+	if !clearedContexts["gitea-mq/ci/lint"] {
+		t.Fatal("expected stale gitea-mq/ci/lint to be reset to pending")
+	}
+	if !clearedContexts["gitea-mq/ci/test"] {
+		t.Fatal("expected stale gitea-mq/ci/test to be reset to pending even though it was already pending")
+	}
+
+	// Non-MQ statuses must not be touched.
+	for _, call := range statusCalls {
+		status := call.Args[3].(gitea.CommitStatus)
+		if status.Context == "ci/build" {
+			t.Fatal("should not touch non-MQ status ci/build")
+		}
+	}
+}
+
+// StartTesting works normally when there are no stale gitea-mq/* statuses to clear.
+func TestStartTesting_NoStaleStatuses(t *testing.T) {
+	mock, svc, ctx, repoID := setup(t)
+
+	mock.MergeBranchesFn = func(_ context.Context, _, _, _, _, _ string) (*gitea.MergeResult, error) {
+		return &gitea.MergeResult{SHA: "mergesha789"}, nil
+	}
+
+	// No gitea-mq/* statuses exist — fresh PR entering the queue for the first time.
+	mock.GetCombinedCommitStatusFn = func(_ context.Context, _, _, ref string) (*gitea.CombinedStatus, error) {
+		return &gitea.CombinedStatus{
+			SHA:   ref,
+			State: "success",
+			Statuses: []gitea.CommitStatusResult{
+				{Context: "ci/build", Status: "success"},
+			},
+		}, nil
+	}
+
+	if _, err := svc.Enqueue(ctx, repoID, 42, "prsha", "main"); err != nil {
+		t.Fatal(err)
+	}
+	entry, _ := svc.GetEntry(ctx, repoID, 42)
+
+	result, err := merge.StartTesting(ctx, mock, svc, "org", "app", repoID, entry, "https://mq.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed {
+		t.Fatal("expected PR to enter testing, not be removed")
+	}
+
+	// Verify GetCombinedCommitStatus was called to check for stale statuses.
+	if len(mock.CallsTo("GetCombinedCommitStatus")) != 1 {
+		t.Fatalf("expected GetCombinedCommitStatus to be called, got %d calls", len(mock.CallsTo("GetCombinedCommitStatus")))
+	}
+
+	// Only the normal "Testing merge result" status should be posted.
+	statusCalls := mock.CallsTo("CreateCommitStatus")
+	if len(statusCalls) != 1 {
+		t.Fatalf("expected 1 CreateCommitStatus call, got %d", len(statusCalls))
+	}
+	status := statusCalls[0].Args[3].(gitea.CommitStatus)
+	if status.Context != "gitea-mq" || status.Description != "Testing merge result" {
+		t.Fatalf("expected 'Testing merge result' status, got %+v", status)
+	}
+}
+
 // CleanupStaleBranches deletes gitea-mq/* branches that have no active queue entry.
 func TestCleanupStaleBranches_DeletesOrphans(t *testing.T) {
 	mock, svc, ctx, repoID := setup(t)

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/jogman/gitea-mq/internal/gitea"
@@ -143,6 +144,11 @@ func HandleSuccess(ctx context.Context, deps *Deps, entry *pg.QueueEntry) error 
 		return fmt.Errorf("set success status for PR #%d: %w", entry.PrNumber, err)
 	}
 
+	// Skip any gitea-mq/* mirrored statuses still pending so the overall
+	// commit status is green. These are from checks that weren't reported
+	// on the merge branch (e.g. cleared from a previous attempt).
+	skipPendingMirroredStatuses(ctx, deps.Gitea, deps.Owner, deps.Repo, entry.PrHeadSha)
+
 	// Delete the merge branch — CI is done, no longer needed.
 	merge.CleanupMergeBranch(ctx, deps.Gitea, deps.Owner, deps.Repo, entry)
 
@@ -152,6 +158,31 @@ func HandleSuccess(ctx context.Context, deps *Deps, entry *pg.QueueEntry) error 
 	}
 
 	return nil
+}
+
+// skipPendingMirroredStatuses sets any gitea-mq/* mirrored statuses that are
+// still pending to skipped. Called on success so leftover pending statuses
+// (e.g. from a previous attempt that were cleared) don't block the green result.
+func skipPendingMirroredStatuses(ctx context.Context, giteaClient gitea.Client, owner, repo, sha string) {
+	combined, err := giteaClient.GetCombinedCommitStatus(ctx, owner, repo, sha)
+	if err != nil {
+		slog.Warn("failed to fetch commit statuses for skip cleanup", "sha", sha, "error", err)
+		return
+	}
+
+	for _, s := range combined.Statuses {
+		if !strings.HasPrefix(s.Context, merge.BranchPrefix) {
+			continue
+		}
+		if s.Status != "pending" || s.Description != merge.StaleMirrorDescription {
+			continue
+		}
+		_ = giteaClient.CreateCommitStatus(ctx, owner, repo, sha, gitea.CommitStatus{
+			Context:     s.Context,
+			State:       "skipped",
+			Description: merge.StaleMirrorDescription,
+		})
+	}
 }
 
 // HandleFailure processes a check failure for the head-of-queue.

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -156,6 +156,56 @@ func TestProcessCheckStatus_Partial_StaysWaiting(t *testing.T) {
 	}
 }
 
+// On success, stale gitea-mq/* statuses (pending with the StaleMirrorDescription)
+// are set to skipped, while other pending statuses and non-pending statuses are
+// left alone.
+func TestProcessCheckStatus_Success_SkipsStaleMirroredStatuses(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupMonitorTest(t)
+	withBranchProtection(mock, "gitea-mq", "ci/build")
+	enqueueTesting(t, svc, ctx, repoID, 42)
+
+	// Simulate stale gitea-mq/* statuses on the PR head from a previous attempt.
+	mock.GetCombinedCommitStatusFn = func(_ context.Context, _, _, _ string) (*gitea.CombinedStatus, error) {
+		return &gitea.CombinedStatus{
+			Statuses: []gitea.CommitStatusResult{
+				{Context: "gitea-mq/ci/old-check", Status: "pending", Description: "From a previous merge queue attempt"},
+				{Context: "gitea-mq/ci/build", Status: "success", Description: "build passed"},               // not pending — leave alone
+				{Context: "gitea-mq/ci/other", Status: "pending", Description: "some other description"},     // wrong description — leave alone
+				{Context: "ci/build", Status: "pending", Description: "From a previous merge queue attempt"}, // not gitea-mq/* — leave alone
+			},
+		}, nil
+	}
+
+	entry, _ := svc.GetEntry(ctx, repoID, 42)
+
+	if err := monitor.ProcessCheckStatus(ctx, deps, entry, "ci/build", pg.CheckStateSuccess, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	statusCalls := mock.CallsTo("CreateCommitStatus")
+
+	// Find the skipped call — should only be gitea-mq/ci/old-check.
+	var skippedContexts []string
+	for _, call := range statusCalls {
+		status := call.Args[3].(gitea.CommitStatus)
+		if status.State == "skipped" {
+			skippedContexts = append(skippedContexts, status.Context)
+		}
+	}
+
+	if len(skippedContexts) != 1 || skippedContexts[0] != "gitea-mq/ci/old-check" {
+		t.Fatalf("expected only gitea-mq/ci/old-check to be skipped, got %v", skippedContexts)
+	}
+
+	// Verify the skipped status has the right description.
+	for _, call := range statusCalls {
+		status := call.Args[3].(gitea.CommitStatus)
+		if status.State == "skipped" && status.Description != "From a previous merge queue attempt" {
+			t.Fatalf("expected skipped status description 'From a previous merge queue attempt', got %q", status.Description)
+		}
+	}
+}
+
 // A check retries: failure → pending → success. The latest state (success)
 // is what counts because SaveCheckStatus upserts.
 func TestProcessCheckStatus_RetrySuccess(t *testing.T) {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -95,6 +95,18 @@ func Handler(secret string, repos RepoLookup, queueSvc *queue.Service) http.Hand
 			return
 		}
 
+		// Mirror the status to the PR head commit with a prefixed context
+		// so users can see merge queue CI progress directly on the PR page.
+		mirrorStatus := gitea.CommitStatus{
+			Context:     "gitea-mq/" + event.Context,
+			State:       event.State,
+			Description: event.Description,
+			TargetURL:   event.TargetURL,
+		}
+		if err := rm.Deps.Gitea.CreateCommitStatus(r.Context(), rm.Deps.Owner, rm.Deps.Repo, entry.PrHeadSha, mirrorStatus); err != nil {
+			slog.Warn("failed to mirror status to PR head", "pr", entry.PrNumber, "context", mirrorStatus.Context, "error", err)
+		}
+
 		checkState := gitea.MapState(event.State)
 
 		if err := monitor.ProcessCheckStatus(r.Context(), rm.Deps, entry, event.Context, checkState, event.TargetURL); err != nil {
@@ -109,11 +121,12 @@ func Handler(secret string, repos RepoLookup, queueSvc *queue.Service) http.Hand
 
 // statusEvent is the subset of Gitea's commit_status webhook payload we need.
 type statusEvent struct {
-	SHA        string `json:"sha"`
-	Context    string `json:"context"`
-	State      string `json:"state"` // "pending", "success", "failure", "error"
-	TargetURL  string `json:"target_url"`
-	Repository struct {
+	SHA         string `json:"sha"`
+	Context     string `json:"context"`
+	State       string `json:"state"` // "pending", "success", "failure", "error"
+	Description string `json:"description"`
+	TargetURL   string `json:"target_url"`
+	Repository  struct {
 		FullName string `json:"full_name"` // "owner/repo"
 	} `json:"repository"`
 }

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/jogman/gitea-mq/internal/gitea"
+	"github.com/jogman/gitea-mq/internal/merge"
 	"github.com/jogman/gitea-mq/internal/monitor"
 	"github.com/jogman/gitea-mq/internal/queue"
+	"github.com/jogman/gitea-mq/internal/store/pg"
 	"github.com/jogman/gitea-mq/internal/testutil"
 	"github.com/jogman/gitea-mq/internal/webhook"
 )
@@ -93,6 +95,24 @@ func doRequest(handler http.Handler, body []byte, sig string) *httptest.Response
 	return rec
 }
 
+// enqueueTesting enqueues a PR and transitions it to testing with a merge branch,
+// which is the precondition for the webhook handler to find the entry.
+func enqueueTesting(t *testing.T, svc *queue.Service, ctx context.Context, repoID, prNumber int64, prHeadSHA, mergeSHA string) {
+	t.Helper()
+
+	if _, err := svc.Enqueue(ctx, repoID, prNumber, prHeadSHA, "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.UpdateState(ctx, repoID, prNumber, pg.EntryStateTesting); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.SetMergeBranch(ctx, repoID, prNumber, merge.BranchName(prNumber), mergeSHA); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // HMAC is the security boundary — verify valid/missing/invalid signatures.
 func TestHandler_SignatureValidation(t *testing.T) {
 	env := setup(t)
@@ -117,5 +137,60 @@ func TestHandler_IgnoresOwnStatus(t *testing.T) {
 
 	if len(env.mock.CallsTo("CreateCommitStatus")) != 0 {
 		t.Fatal("should not process own status — feedback loop risk")
+	}
+}
+
+// Verifies that a CI status on the merge branch is mirrored to the PR head
+// with a "gitea-mq/" prefix so users see queue progress on their PR.
+func TestHandler_MirrorsStatusToPRHead(t *testing.T) {
+	env := setup(t)
+
+	const (
+		prHeadSHA = "pr-head-abc"
+		mergeSHA  = "merge-branch-def"
+		prNumber  = int64(7)
+	)
+
+	enqueueTesting(t, env.svc, env.ctx, env.repoID, prNumber, prHeadSHA, mergeSHA)
+
+	payload := map[string]any{
+		"sha":         mergeSHA,
+		"context":     "ci/build",
+		"state":       "success",
+		"description": "build passed",
+		"target_url":  "https://ci.example.com/build/1",
+		"repository":  map[string]string{"full_name": "org/app"},
+	}
+	body, _ := json.Marshal(payload)
+
+	rec := doRequest(env.handler, body, sign(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Find the mirror call: CreateCommitStatus on the PR head with prefixed context.
+	var mirror *gitea.MockCall
+	for _, c := range env.mock.CallsTo("CreateCommitStatus") {
+		sha := c.Args[2].(string)
+		status := c.Args[3].(gitea.CommitStatus)
+		if sha == prHeadSHA && status.Context == "gitea-mq/ci/build" {
+			mirror = &c
+			break
+		}
+	}
+
+	if mirror == nil {
+		t.Fatal("expected CreateCommitStatus mirror call on PR head, not found")
+	}
+
+	status := mirror.Args[3].(gitea.CommitStatus)
+	if status.State != "success" {
+		t.Errorf("mirror state = %q, want %q", status.State, "success")
+	}
+	if status.Description != "build passed" {
+		t.Errorf("mirror description = %q, want %q", status.Description, "build passed")
+	}
+	if status.TargetURL != "https://ci.example.com/build/1" {
+		t.Errorf("mirror target_url = %q, want %q", status.TargetURL, "https://ci.example.com/build/1")
 	}
 }

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -261,6 +261,15 @@ pkgs.testers.runNixOSTest {
         timeout=30,
     )
 
+    # Verify the merge branch CI status was mirrored to the PR head
+    # with a prefixed context.
+    machine.wait_until_succeeds(
+        f"curl -sf 'http://localhost:3000/api/v1/repos/testuser/testrepo/statuses/{pr_sha}' "
+        f"-H 'Authorization: token {token}' "
+        f"| jq -e '.[] | select(.context == \"gitea-mq/ci/build\" and .status == \"success\" and .description == \"build passed\")'",
+        timeout=30,
+    )
+
     # Also set ci/build=success on the PR head so Gitea's automerge sees
     # all required checks passing on the PR itself.
     machine.succeed(


### PR DESCRIPTION
# Before

<img width="911" height="220" alt="Screenshot 2026-03-19 at 11 11 28 am" src="https://github.com/user-attachments/assets/f4e7e455-e06f-4a2b-9a83-504a94d14d76" />

<img width="912" height="219" alt="Screenshot 2026-03-19 at 11 11 46 am" src="https://github.com/user-attachments/assets/882270a6-c184-4f29-893c-3ceba119f10a" />

# After

<img width="906" height="299" alt="Screenshot 2026-03-19 at 11 15 17 am" src="https://github.com/user-attachments/assets/280e642c-bdfb-4c98-b61c-fe0a11a28f36" />
<img width="908" height="339" alt="Screenshot 2026-03-19 at 11 17 02 am" src="https://github.com/user-attachments/assets/e862624f-9b84-49e9-8cf6-628ba413e32a" />