### PR TITLE
Create a static CSS file

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -19,7 +19,7 @@ import (
 	"github.com/jogman/gitea-mq/internal/store/pg"
 )
 
-//go:embed templates/*.html
+//go:embed templates/*.html templates/*.css
 var templateFS embed.FS
 
 // funcMap provides template helper functions.


### PR DESCRIPTION
`/static/style.css` was always giving me 404. 

The `staticCSSHandler` uses `templateFS.ReadFile("templates/style.css")` and the `templateFS` is an embedded FS:

```
//go:embed templates/*.html templates/*.css
var templateFS embed.FS
```

So I guess we need to add the .css here. I'm not sure how this has been working for anyone else.