### PR TITLE
discovery: fix repos with correct topic not found

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -6,7 +6,6 @@ package discovery
 import (
 	"context"
 	"log/slog"
-	"slices"
 	"time"
 
 	"github.com/jogman/gitea-mq/internal/config"
@@ -22,38 +21,23 @@ type Deps struct {
 	ExplicitRepos []config.RepoRef
 }
 
-// DiscoverOnce runs a single discovery cycle: lists repos, fetches topics,
-// filters by topic + admin access, merges with explicit repos, and reconciles
+// DiscoverOnce runs a single discovery cycle: searches repos by topic,
+// filters by admin access, merges with explicit repos, and reconciles
 // the registry.
 func DiscoverOnce(ctx context.Context, deps *Deps) error {
-	repos, err := deps.Gitea.ListUserRepos(ctx)
+	repos, err := deps.Gitea.SearchReposByTopic(ctx, deps.Topic)
 	if err != nil {
-		slog.Warn("discovery: failed to list user repos", "error", err)
+		slog.Warn("discovery: failed to search repos by topic", "error", err)
 		return err
 	}
 
 	// Build the desired set from topic-discovered repos.
-	// Track repos where topic fetch failed so we don't remove them
-	// from the managed set (conservative: keep on partial failure).
 	desired := make(map[string]config.RepoRef)
-	topicFetchFailed := make(map[string]struct{})
 
 	for _, repo := range repos {
 		if !repo.Permissions.Admin {
 			slog.Debug("discovery: skipping repo without admin access",
 				"repo", repo.FullName)
-			continue
-		}
-
-		topics, err := deps.Gitea.GetRepoTopics(ctx, repo.Owner.Login, repo.Name)
-		if err != nil {
-			slog.Warn("discovery: failed to fetch topics, skipping repo",
-				"repo", repo.FullName, "error", err)
-			topicFetchFailed[repo.FullName] = struct{}{}
-			continue
-		}
-
-		if !slices.Contains(topics, deps.Topic) {
 			continue
 		}
 
@@ -85,12 +69,6 @@ func DiscoverOnce(ctx context.Context, deps *Deps) error {
 	for key := range deps.Registry.Keys() {
 		if _, inDesired := desired[key]; !inDesired {
 			if _, isExplicit := explicitSet[key]; isExplicit {
-				continue
-			}
-			// Don't remove repos whose topic fetch failed — they might
-			// still have the topic, we just couldn't verify.
-			if _, failed := topicFetchFailed[key]; failed {
-				slog.Debug("discovery: keeping repo with failed topic fetch", "repo", key)
 				continue
 			}
 			slog.Info("discovery: removing repo", "repo", key)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -39,23 +39,15 @@ func newTestSetup(t *testing.T) (*registry.RepoRegistry, *gitea.MockClient, cont
 func TestDiscoverOnce_TopicMatching(t *testing.T) {
 	reg, mock, ctx := newTestSetup(t)
 
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
+	// SearchReposByTopic returns only repos that already have the topic,
+	// so only org/app should be returned by the search.
+	mock.SearchReposByTopicFn = func(_ context.Context, topic string) ([]gitea.Repo, error) {
+		if topic != "merge-queue" {
+			return nil, nil
+		}
 		return []gitea.Repo{
 			{FullName: "org/app", Owner: gitea.RepoOwner{Login: "org"}, Name: "app", Permissions: gitea.RepoPermissions{Admin: true}},
-			{FullName: "org/lib", Owner: gitea.RepoOwner{Login: "org"}, Name: "lib", Permissions: gitea.RepoPermissions{Admin: true}},
-			{FullName: "org/docs", Owner: gitea.RepoOwner{Login: "org"}, Name: "docs", Permissions: gitea.RepoPermissions{Admin: true}},
 		}, nil
-	}
-	mock.GetRepoTopicsFn = func(_ context.Context, owner, repo string) ([]string, error) {
-		switch owner + "/" + repo {
-		case "org/app":
-			return []string{"merge-queue", "go"}, nil
-		case "org/lib":
-			return []string{"nix", "library"}, nil
-		case "org/docs":
-			return []string{}, nil
-		}
-		return nil, nil
 	}
 
 	deps := &discovery.Deps{
@@ -71,25 +63,16 @@ func TestDiscoverOnce_TopicMatching(t *testing.T) {
 	if !reg.Contains("org/app") {
 		t.Error("expected org/app to be discovered (has merge-queue topic)")
 	}
-	if reg.Contains("org/lib") {
-		t.Error("expected org/lib to NOT be discovered (no merge-queue topic)")
-	}
-	if reg.Contains("org/docs") {
-		t.Error("expected org/docs to NOT be discovered (no topics)")
-	}
 }
 
 func TestDiscoverOnce_AdminFilter(t *testing.T) {
 	reg, mock, ctx := newTestSetup(t)
 
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
 		return []gitea.Repo{
 			{FullName: "org/admin-repo", Owner: gitea.RepoOwner{Login: "org"}, Name: "admin-repo", Permissions: gitea.RepoPermissions{Admin: true}},
 			{FullName: "org/read-repo", Owner: gitea.RepoOwner{Login: "org"}, Name: "read-repo", Permissions: gitea.RepoPermissions{Admin: false, Pull: true}},
 		}, nil
-	}
-	mock.GetRepoTopicsFn = func(_ context.Context, _, _ string) ([]string, error) {
-		return []string{"merge-queue"}, nil
 	}
 
 	deps := &discovery.Deps{
@@ -113,13 +96,10 @@ func TestDiscoverOnce_AdminFilter(t *testing.T) {
 func TestDiscoverOnce_RemovesRepoThatLostTopic(t *testing.T) {
 	reg, mock, ctx := newTestSetup(t)
 
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
 		return []gitea.Repo{
 			{FullName: "org/app", Owner: gitea.RepoOwner{Login: "org"}, Name: "app", Permissions: gitea.RepoPermissions{Admin: true}},
 		}, nil
-	}
-	mock.GetRepoTopicsFn = func(_ context.Context, _, _ string) ([]string, error) {
-		return []string{"merge-queue"}, nil
 	}
 
 	deps := &discovery.Deps{
@@ -135,9 +115,9 @@ func TestDiscoverOnce_RemovesRepoThatLostTopic(t *testing.T) {
 		t.Fatal("expected org/app after first cycle")
 	}
 
-	// Second cycle: org/app lost the topic.
-	mock.GetRepoTopicsFn = func(_ context.Context, _, _ string) ([]string, error) {
-		return []string{"go"}, nil
+	// Second cycle: org/app lost the topic (no longer returned by search).
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
+		return nil, nil
 	}
 
 	if err := discovery.DiscoverOnce(ctx, deps); err != nil {
@@ -151,13 +131,10 @@ func TestDiscoverOnce_RemovesRepoThatLostTopic(t *testing.T) {
 func TestDiscoverOnce_ExplicitRepoNeverRemoved(t *testing.T) {
 	reg, mock, ctx := newTestSetup(t)
 
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
 		return []gitea.Repo{
 			{FullName: "org/app", Owner: gitea.RepoOwner{Login: "org"}, Name: "app", Permissions: gitea.RepoPermissions{Admin: true}},
 		}, nil
-	}
-	mock.GetRepoTopicsFn = func(_ context.Context, _, _ string) ([]string, error) {
-		return []string{"merge-queue"}, nil
 	}
 
 	deps := &discovery.Deps{
@@ -179,8 +156,8 @@ func TestDiscoverOnce_ExplicitRepoNeverRemoved(t *testing.T) {
 	}
 
 	// Second cycle: no repos discovered at all, but explicit stays.
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
-		return []gitea.Repo{}, nil
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
+		return nil, nil
 	}
 
 	if err := discovery.DiscoverOnce(ctx, deps); err != nil {
@@ -197,13 +174,10 @@ func TestDiscoverOnce_ExplicitRepoNeverRemoved(t *testing.T) {
 func TestDiscoverOnce_APIFailureKeepsCurrentSet(t *testing.T) {
 	reg, mock, ctx := newTestSetup(t)
 
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
 		return []gitea.Repo{
 			{FullName: "org/app", Owner: gitea.RepoOwner{Login: "org"}, Name: "app", Permissions: gitea.RepoPermissions{Admin: true}},
 		}, nil
-	}
-	mock.GetRepoTopicsFn = func(_ context.Context, _, _ string) ([]string, error) {
-		return []string{"merge-queue"}, nil
 	}
 
 	deps := &discovery.Deps{Gitea: mock, Registry: reg, Topic: "merge-queue"}
@@ -212,7 +186,7 @@ func TestDiscoverOnce_APIFailureKeepsCurrentSet(t *testing.T) {
 		t.Fatal("setup failed")
 	}
 
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
+	mock.SearchReposByTopicFn = func(_ context.Context, _ string) ([]gitea.Repo, error) {
 		return nil, fmt.Errorf("connection refused")
 	}
 
@@ -222,43 +196,5 @@ func TestDiscoverOnce_APIFailureKeepsCurrentSet(t *testing.T) {
 	}
 	if !reg.Contains("org/app") {
 		t.Error("expected org/app to remain managed after API failure")
-	}
-}
-
-func TestDiscoverOnce_PartialTopicFetchKeepsManagedRepo(t *testing.T) {
-	reg, mock, ctx := newTestSetup(t)
-
-	mock.ListUserReposFn = func(_ context.Context) ([]gitea.Repo, error) {
-		return []gitea.Repo{
-			{FullName: "org/app", Owner: gitea.RepoOwner{Login: "org"}, Name: "app", Permissions: gitea.RepoPermissions{Admin: true}},
-			{FullName: "org/lib", Owner: gitea.RepoOwner{Login: "org"}, Name: "lib", Permissions: gitea.RepoPermissions{Admin: true}},
-		}, nil
-	}
-	mock.GetRepoTopicsFn = func(_ context.Context, _, _ string) ([]string, error) {
-		return []string{"merge-queue"}, nil
-	}
-
-	deps := &discovery.Deps{Gitea: mock, Registry: reg, Topic: "merge-queue"}
-	_ = discovery.DiscoverOnce(ctx, deps)
-	if !reg.Contains("org/app") || !reg.Contains("org/lib") {
-		t.Fatal("setup failed")
-	}
-
-	// Second cycle: topic fetch fails for org/app only.
-	mock.GetRepoTopicsFn = func(_ context.Context, _, repo string) ([]string, error) {
-		if repo == "app" {
-			return nil, fmt.Errorf("timeout")
-		}
-		return []string{"merge-queue"}, nil
-	}
-
-	_ = discovery.DiscoverOnce(ctx, deps)
-
-	// Spec: "if org/app was previously managed, it remains managed (no removal on partial failure)"
-	if !reg.Contains("org/app") {
-		t.Error("org/app should remain managed when its topic fetch failed (conservative reconciliation)")
-	}
-	if !reg.Contains("org/lib") {
-		t.Error("org/lib should remain managed (topic fetch succeeded)")
 	}
 }

--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -179,14 +179,11 @@ func MapState(s string) pg.CheckState {
 // Client defines the Gitea API surface used by gitea-mq.
 // All methods accept a context for cancellation and return an error on failure.
 type Client interface {
-	// ListUserRepos returns all repositories accessible to the authenticated user.
-	// Handles pagination internally.
-	// GET /user/repos
-	ListUserRepos(ctx context.Context) ([]Repo, error)
-
-	// GetRepoTopics returns the topics for a repository.
-	// GET /repos/{owner}/{repo}/topics
-	GetRepoTopics(ctx context.Context, owner, repo string) ([]string, error)
+	// SearchReposByTopic returns all repositories with the given topic.
+	// Uses the search endpoint which, for site admins, returns repos across the
+	// entire instance — not just repos the user owns or collaborates on.
+	// GET /repos/search?q={topic}&topic=true
+	SearchReposByTopic(ctx context.Context, topic string) ([]Repo, error)
 
 	// ListOpenPRs returns all open pull requests for a repository.
 	ListOpenPRs(ctx context.Context, owner, repo string) ([]PR, error)

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -190,30 +190,35 @@ func paginateAll[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel st
 	}
 }
 
-// ListUserRepos returns all repositories accessible to the authenticated user.
-// Handles pagination.
-func (c *HTTPClient) ListUserRepos(ctx context.Context) ([]Repo, error) {
-	return paginate[Repo](ctx, c, "/user/repos?page=%d&limit=50", "list user repos")
-}
+// SearchReposByTopic returns all repositories with the given topic.
+// Uses the search endpoint which, for site admins, returns repos across the
+// entire instance — not just repos the user owns or collaborates on.
+// The /repos/search endpoint wraps results in {"ok": true, "data": [...]},
+// so we can't use the generic paginate helper.
+func (c *HTTPClient) SearchReposByTopic(ctx context.Context, topic string) ([]Repo, error) {
+	var all []Repo
 
-// GetRepoTopics returns the topics for a repository.
-// Gitea doesn't include topics in the repo listing, so this needs a separate call.
-func (c *HTTPClient) GetRepoTopics(ctx context.Context, owner, repo string) ([]string, error) {
-	path := fmt.Sprintf("/repos/%s/%s/topics", owner, repo)
+	for page := 1; ; page++ {
+		path := fmt.Sprintf("/repos/search?q=%s&topic=true&page=%d&limit=50", topic, page)
 
-	resp, err := c.do(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
+		resp, err := c.do(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var result struct {
+			Data []Repo `json:"data"`
+		}
+		if err := c.decodeJSON(resp, &result); err != nil {
+			return nil, fmt.Errorf("search repos by topic %s: %w", topic, err)
+		}
+
+		if len(result.Data) == 0 {
+			return all, nil
+		}
+
+		all = append(all, result.Data...)
 	}
-
-	var result struct {
-		Topics []string `json:"topics"`
-	}
-	if err := c.decodeJSON(resp, &result); err != nil {
-		return nil, fmt.Errorf("get topics for %s/%s: %w", owner, repo, err)
-	}
-
-	return result.Topics, nil
 }
 
 // ListOpenPRs returns all open pull requests for a repository.

--- a/internal/gitea/mock.go
+++ b/internal/gitea/mock.go
@@ -21,8 +21,7 @@ type MockClient struct {
 	// Response configurators. Set these before calling the method under test.
 	// Each returns (result, error). If nil, the method returns zero value + nil.
 
-	ListUserReposFn           func(ctx context.Context) ([]Repo, error)
-	GetRepoTopicsFn           func(ctx context.Context, owner, repo string) ([]string, error)
+	SearchReposByTopicFn      func(ctx context.Context, topic string) ([]Repo, error)
 	ListOpenPRsFn             func(ctx context.Context, owner, repo string) ([]PR, error)
 	GetPRFn                   func(ctx context.Context, owner, repo string, index int64) (*PR, error)
 	GetPRTimelineFn           func(ctx context.Context, owner, repo string, index int64) ([]TimelineComment, error)
@@ -74,21 +73,11 @@ func (m *MockClient) Reset() {
 	m.Calls = nil
 }
 
-func (m *MockClient) ListUserRepos(ctx context.Context) ([]Repo, error) {
-	m.record("ListUserRepos")
+func (m *MockClient) SearchReposByTopic(ctx context.Context, topic string) ([]Repo, error) {
+	m.record("SearchReposByTopic", topic)
 
-	if m.ListUserReposFn != nil {
-		return m.ListUserReposFn(ctx)
-	}
-
-	return nil, nil
-}
-
-func (m *MockClient) GetRepoTopics(ctx context.Context, owner, repo string) ([]string, error) {
-	m.record("GetRepoTopics", owner, repo)
-
-	if m.GetRepoTopicsFn != nil {
-		return m.GetRepoTopicsFn(ctx, owner, repo)
+	if m.SearchReposByTopicFn != nil {
+		return m.SearchReposByTopicFn(ctx, topic)
 	}
 
 	return nil, nil

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -414,5 +414,36 @@ pkgs.testers.runNixOSTest {
         "curl -sf http://localhost:8080/ | grep -q 'testuser/discovered-repo'",
         timeout=30,
     )
+
+    # When gitea-mq is a Gitea site admin, it should discover all repos
+    # with the configured topic — even ones it isn't a collaborator on.
+    #
+    # This test creates a repo owned by a different user with the
+    # merge-queue topic and verifies discovery picks it up.
+
+    # Create a second (non-admin) user via the Gitea CLI.
+    machine.succeed(
+        "su -l gitea -c '"
+        "GITEA_WORK_DIR=/var/lib/gitea gitea admin user create --username otheruser --password otherpass123 --email other@test.com"
+        "'"
+    )
+
+    # Admin creates a repo under otheruser via the admin API.
+    machine.succeed(
+        f"curl -sf -X POST http://localhost:3000/api/v1/admin/users/otheruser/repos "
+        f"-H 'Authorization: token {token}' "
+        f"-H 'Content-Type: application/json' "
+        f"-d '{{\"name\": \"other-repo\", \"auto_init\": true, \"default_branch\": \"main\"}}'"
+    )
+    machine.succeed(
+        f"curl -sf -X PUT 'http://localhost:3000/api/v1/repos/otheruser/other-repo/topics/merge-queue' "
+        f"-H 'Authorization: token {token}'"
+    )
+
+    # The admin's gitea-mq should discover otheruser/other-repo via the topic.
+    machine.wait_until_succeeds(
+        "curl -sf http://localhost:8080/ | grep -q 'otheruser/other-repo'",
+        timeout=60,
+    )
   '';
 }


### PR DESCRIPTION
Currently, even if `gitea-mq` is a Gitea-wide administrator and a repo has the correct topic, it won't be discovered unless it is added as a collaborator

Marking it as a draft as I haven't tested this by hand yet