### PR TITLE
poller: time out PRs stuck in testing without check status

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -32,6 +32,11 @@ type Deps struct {
 	// SuccessTimeout is how long a PR may sit in "success" without merging
 	// before we assume the forge's auto-merge failed.
 	SuccessTimeout time.Duration
+	// CheckTimeout is how long a PR may sit in "testing" without a check
+	// status before we abandon it. Without this, a CI server that loses a
+	// build (e.g. a restart) leaves the head-of-queue stuck forever since
+	// the timeout in monitor.ProcessCheckStatus only runs on webhooks.
+	CheckTimeout time.Duration
 }
 
 type PollResult struct {
@@ -250,6 +255,7 @@ func reconcileEntries(ctx context.Context, deps *Deps, result *PollResult, openP
 		}
 		if !matched {
 			handleSuccessTimeout(ctx, deps, result, &entry)
+			handleTestingTimeout(ctx, deps, result, &entry)
 		}
 	}
 }
@@ -276,6 +282,33 @@ func handleSuccessTimeout(ctx context.Context, deps *Deps, result *PollResult, e
 		logMsg:          "removed PR due to success-but-not-merged timeout",
 	}); err != nil {
 		result.Errors = append(result.Errors, fmt.Errorf("dequeue timed-out PR #%d: %w", entry.PrNumber, err))
+	}
+}
+
+// handleTestingTimeout removes entries that have been in "testing" longer
+// than CheckTimeout without reaching a terminal state. The webhook-driven
+// timeout in monitor only fires when a check status arrives; if the CI never
+// reports (e.g. it lost the build after a restart), the queue stalls.
+func handleTestingTimeout(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry) {
+	if entry.State != pg.EntryStateTesting || deps.CheckTimeout <= 0 ||
+		!entry.TestingStartedAt.Valid || time.Since(entry.TestingStartedAt.Time) <= deps.CheckTimeout {
+		return
+	}
+
+	targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, entry.PrNumber)
+	_ = deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, entry.PrHeadSha, forge.MQStatus{
+		State: pg.CheckStateError, Description: "CI did not report within timeout", TargetURL: targetURL,
+	})
+	_ = deps.Queue.SetError(ctx, deps.RepoID, entry.PrNumber, "CI did not report within timeout")
+	merge.CleanupMergeBranch(ctx, deps.Forge, deps.Owner, deps.Repo, entry)
+
+	if err := removePR(ctx, deps, result, entry, removeOpts{
+		cancelAutomerge: true,
+		comment:         "⚠️ Removed from merge queue: CI did not report a status within the timeout. The CI server may have lost the build.",
+		advance:         true,
+		logMsg:          "removed PR due to testing timeout",
+	}); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("dequeue timed-out testing PR #%d: %w", entry.PrNumber, err))
 	}
 }
 

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -214,6 +214,39 @@ func TestPollOnce_RemoveHead_CleansUpMergeBranch(t *testing.T) {
 	}
 }
 
+func TestPollOnce_TestingNeverReports_TimesOut(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupPollerTest(t)
+	deps.CheckTimeout = 1 * time.Millisecond
+
+	if _, err := svc.Enqueue(ctx, repoID, 42, "sha42", "main"); err != nil {
+		t.Fatal(err)
+	}
+	_ = svc.UpdateState(ctx, repoID, 42, pg.EntryStateTesting)
+	time.Sleep(5 * time.Millisecond)
+
+	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
+		return []gitea.PR{makePR(42, "sha42", "main")}, nil
+	}
+	mock.GetPRTimelineFn = func(_ context.Context, _, _ string, _ int64) ([]gitea.TimelineComment, error) {
+		return automergeTimeline(), nil
+	}
+
+	result, err := poller.PollOnce(ctx, deps)
+	if err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(result.Dequeued) != 1 || result.Dequeued[0] != 42 {
+		t.Fatalf("expected PR #42 dequeued, got %v", result.Dequeued)
+	}
+	if len(mock.CallsTo("CancelAutoMerge")) != 1 {
+		t.Fatal("expected CancelAutoMerge call")
+	}
+	statusCalls := mock.CallsTo("CreateCommitStatus")
+	if len(statusCalls) != 1 || statusCalls[0].Args[3].(gitea.CommitStatus).State != "error" {
+		t.Fatalf("expected single error status, got %v", statusCalls)
+	}
+}
+
 func TestPollOnce_SuccessButNotMerged_TimesOut(t *testing.T) {
 	deps, mock, svc, ctx, repoID := setupPollerTest(t)
 	deps.SuccessTimeout = 1 * time.Millisecond

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -132,6 +132,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		ExternalURL:    r.deps.ExternalURL,
 		FallbackChecks: r.deps.FallbackChecks,
 		SuccessTimeout: r.deps.SuccessTimeout,
+		CheckTimeout:   r.deps.CheckTimeout,
 	}
 	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval)
 


### PR DESCRIPTION
The CheckTimeout in monitor.ProcessCheckStatus only runs when a webhook
delivers a commit status. If the CI server loses a build (e.g. after a
restart), no status ever arrives and the head-of-queue stays in
"testing" forever, blocking everything behind it.

Add a poller sweep that removes entries that have been testing longer
than CheckTimeout, mirroring handleSuccessTimeout.
