### PR TITLE
gitea: check all pages of commit statuses

### DIFF
--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -135,11 +135,32 @@ func IsNotFound(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }
 
-// paginate fetches all pages of a paginated Gitea API endpoint.
-// pathFmt must contain a single %d verb for the page number (e.g. "/user/repos?page=%d&limit=50").
-// Stops when a page returns fewer items than the limit (50).
+// paginate fetches all pages of a Gitea API endpoint that returns a bare
+// JSON array. pathFmt must contain a single %d verb for the page number
+// (e.g. "/user/repos?page=%d&limit=50"). A short page (< 50 items) is
+// treated as the last page, saving a final empty-page request when the
+// data divides evenly. Use this for endpoints whose page size exactly
+// matches the SQL LIMIT — i.e. most of Gitea's list endpoints.
 func paginate[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel string) ([]T, error) {
-	var all []T
+	return paginateWrapped(ctx, c, pathFmt, errLabel, func(s *[]T) []T { return *s })
+}
+
+// paginateUntilEmpty is like paginate but keeps fetching until a page
+// comes back empty. Use this for endpoints where Gitea applies a
+// post-decode filter after the SQL LIMIT (the timeline endpoint hides
+// CommentTypeCode entries this way), so a non-final page can legitimately
+// be shorter than the limit and "short page = last page" would skip data.
+// Costs one extra HTTP request per call.
+func paginateUntilEmpty[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel string) ([]T, error) {
+	return paginateWrappedUntilEmpty(ctx, c, pathFmt, errLabel, func(s *[]T) []T { return *s })
+}
+
+// paginateWrapped is paginate for endpoints whose JSON response is a
+// wrapping object instead of a bare array (e.g. /repos/search returns
+// {ok, data: [...]}). extract pulls the page items out of the decoded
+// wrapper. Same EOF contract as paginate.
+func paginateWrapped[Wrapper, Item any](ctx context.Context, c *HTTPClient, pathFmt, errLabel string, extract func(*Wrapper) []Item) ([]Item, error) {
+	var all []Item
 
 	for page := 1; ; page++ {
 		path := fmt.Sprintf(pathFmt, page)
@@ -149,11 +170,12 @@ func paginate[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel strin
 			return nil, err
 		}
 
-		var items []T
-		if err := c.decodeJSON(resp, &items); err != nil {
+		var w Wrapper
+		if err := c.decodeJSON(resp, &w); err != nil {
 			return nil, fmt.Errorf("%s: %w", errLabel, err)
 		}
 
+		items := extract(&w)
 		all = append(all, items...)
 
 		if len(items) < 50 {
@@ -162,12 +184,10 @@ func paginate[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel strin
 	}
 }
 
-// paginateAll is like paginate but keeps fetching until an empty page is
-// returned. Use this for endpoints where Gitea filters items after applying
-// the SQL LIMIT (e.g. the timeline endpoint filters CommentTypeCode entries),
-// which can return fewer items than the limit on non-final pages.
-func paginateAll[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel string) ([]T, error) {
-	var all []T
+// paginateWrappedUntilEmpty is paginateUntilEmpty for wrapped responses.
+// Same EOF contract as paginateUntilEmpty.
+func paginateWrappedUntilEmpty[Wrapper, Item any](ctx context.Context, c *HTTPClient, pathFmt, errLabel string, extract func(*Wrapper) []Item) ([]Item, error) {
+	var all []Item
 
 	for page := 1; ; page++ {
 		path := fmt.Sprintf(pathFmt, page)
@@ -177,11 +197,12 @@ func paginateAll[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel st
 			return nil, err
 		}
 
-		var items []T
-		if err := c.decodeJSON(resp, &items); err != nil {
+		var w Wrapper
+		if err := c.decodeJSON(resp, &w); err != nil {
 			return nil, fmt.Errorf("%s: %w", errLabel, err)
 		}
 
+		items := extract(&w)
 		if len(items) == 0 {
 			return all, nil
 		}
@@ -190,35 +211,19 @@ func paginateAll[T any](ctx context.Context, c *HTTPClient, pathFmt, errLabel st
 	}
 }
 
+// repoSearchResponse is the wrapping object returned by /repos/search.
+type repoSearchResponse struct {
+	Data []Repo `json:"data"`
+}
+
 // SearchReposByTopic returns all repositories with the given topic.
 // Uses the search endpoint which, for site admins, returns repos across the
 // entire instance — not just repos the user owns or collaborates on.
-// The /repos/search endpoint wraps results in {"ok": true, "data": [...]},
-// so we can't use the generic paginate helper.
 func (c *HTTPClient) SearchReposByTopic(ctx context.Context, topic string) ([]Repo, error) {
-	var all []Repo
-
-	for page := 1; ; page++ {
-		path := fmt.Sprintf("/repos/search?q=%s&topic=true&page=%d&limit=50", topic, page)
-
-		resp, err := c.do(ctx, http.MethodGet, path, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		var result struct {
-			Data []Repo `json:"data"`
-		}
-		if err := c.decodeJSON(resp, &result); err != nil {
-			return nil, fmt.Errorf("search repos by topic %s: %w", topic, err)
-		}
-
-		if len(result.Data) == 0 {
-			return all, nil
-		}
-
-		all = append(all, result.Data...)
-	}
+	return paginateWrappedUntilEmpty(ctx, c,
+		fmt.Sprintf("/repos/search?q=%s&topic=true&page=%%d&limit=50", topic),
+		fmt.Sprintf("search repos by topic %s", topic),
+		func(r *repoSearchResponse) []Repo { return r.Data })
 }
 
 // ListOpenPRs returns all open pull requests for a repository.
@@ -249,7 +254,7 @@ func (c *HTTPClient) GetPR(ctx context.Context, owner, repo string, index int64)
 // GetPRTimeline returns timeline comments for a pull request.
 // Handles pagination. The endpoint is GET /repos/{owner}/{repo}/issues/{index}/timeline.
 func (c *HTTPClient) GetPRTimeline(ctx context.Context, owner, repo string, index int64) ([]TimelineComment, error) {
-	return paginateAll[TimelineComment](ctx, c,
+	return paginateUntilEmpty[TimelineComment](ctx, c,
 		fmt.Sprintf("/repos/%s/%s/issues/%d/timeline?page=%%d&limit=50", owner, repo, index),
 		fmt.Sprintf("get PR #%d timeline in %s/%s", index, owner, repo))
 }
@@ -257,27 +262,14 @@ func (c *HTTPClient) GetPRTimeline(ctx context.Context, owner, repo string, inde
 // GetCombinedCommitStatus returns the latest status per context for a commit
 // ref by paginating GET /repos/{owner}/{repo}/commits/{ref}/status.
 func (c *HTTPClient) GetCombinedCommitStatus(ctx context.Context, owner, repo, ref string) (*CombinedStatus, error) {
-	cs := &CombinedStatus{SHA: ref}
-
-	for page := 1; ; page++ {
-		path := fmt.Sprintf("/repos/%s/%s/commits/%s/status?page=%d&limit=50", owner, repo, ref, page)
-
-		resp, err := c.do(ctx, http.MethodGet, path, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		var pageCS CombinedStatus
-		if err := c.decodeJSON(resp, &pageCS); err != nil {
-			return nil, fmt.Errorf("get combined status for %s in %s/%s: %w", shortSHA(ref), owner, repo, err)
-		}
-
-		cs.Statuses = append(cs.Statuses, pageCS.Statuses...)
-
-		if len(pageCS.Statuses) < 50 {
-			return cs, nil
-		}
+	statuses, err := paginateWrapped(ctx, c,
+		fmt.Sprintf("/repos/%s/%s/commits/%s/status?page=%%d&limit=50", owner, repo, ref),
+		fmt.Sprintf("get combined status for %s in %s/%s", shortSHA(ref), owner, repo),
+		func(cs *CombinedStatus) []CommitStatusResult { return cs.Statuses })
+	if err != nil {
+		return nil, err
 	}
+	return &CombinedStatus{SHA: ref, Statuses: statuses}, nil
 }
 
 // CreateCommitStatus posts a commit status on a specific SHA.

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -254,22 +254,30 @@ func (c *HTTPClient) GetPRTimeline(ctx context.Context, owner, repo string, inde
 		fmt.Sprintf("get PR #%d timeline in %s/%s", index, owner, repo))
 }
 
-// GetCombinedCommitStatus returns the combined status for a commit ref.
-// GET /repos/{owner}/{repo}/commits/{ref}/status
+// GetCombinedCommitStatus returns the latest status per context for a commit
+// ref by paginating GET /repos/{owner}/{repo}/commits/{ref}/status.
 func (c *HTTPClient) GetCombinedCommitStatus(ctx context.Context, owner, repo, ref string) (*CombinedStatus, error) {
-	path := fmt.Sprintf("/repos/%s/%s/commits/%s/status", owner, repo, ref)
+	cs := &CombinedStatus{SHA: ref}
 
-	resp, err := c.do(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
+	for page := 1; ; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/commits/%s/status?page=%d&limit=50", owner, repo, ref, page)
+
+		resp, err := c.do(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var pageCS CombinedStatus
+		if err := c.decodeJSON(resp, &pageCS); err != nil {
+			return nil, fmt.Errorf("get combined status for %s in %s/%s: %w", shortSHA(ref), owner, repo, err)
+		}
+
+		cs.Statuses = append(cs.Statuses, pageCS.Statuses...)
+
+		if len(pageCS.Statuses) < 50 {
+			return cs, nil
+		}
 	}
-
-	var cs CombinedStatus
-	if err := c.decodeJSON(resp, &cs); err != nil {
-		return nil, fmt.Errorf("get combined status for %s in %s/%s: %w", shortSHA(ref), owner, repo, err)
-	}
-
-	return &cs, nil
 }
 
 // CreateCommitStatus posts a commit status on a specific SHA.

--- a/internal/gitea/pagination_test.go
+++ b/internal/gitea/pagination_test.go
@@ -1,0 +1,153 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// pageStub records the sequence of `page` query values served and returns
+// canned item counts per page. limit=50 is asserted on every request.
+type pageStub struct {
+	t        *testing.T
+	requests []string
+	counts   map[int]int // page → item count
+}
+
+func newPageStub(t *testing.T, counts map[int]int) *pageStub {
+	return &pageStub{t: t, counts: counts}
+}
+
+func (s *pageStub) handler(encode func(w http.ResponseWriter, items []int)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if got := q.Get("limit"); got != "50" {
+			s.t.Errorf("limit param = %q, want 50", got)
+		}
+		page, _ := strconv.Atoi(q.Get("page"))
+		s.requests = append(s.requests, q.Get("page"))
+
+		count, ok := s.counts[page]
+		if !ok {
+			s.t.Errorf("unexpected request for page=%d", page)
+			http.Error(w, "unexpected page", http.StatusInternalServerError)
+			return
+		}
+		items := make([]int, count)
+		for i := range items {
+			items[i] = page*1000 + i
+		}
+		encode(w, items)
+	})
+}
+
+func encodeBare(w http.ResponseWriter, items []int) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(items)
+}
+
+type itemsWrapper struct {
+	Meta  string `json:"meta"`
+	Items []int  `json:"items"`
+}
+
+func encodeWrapped(w http.ResponseWriter, items []int) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(itemsWrapper{Meta: "ignored", Items: items})
+}
+
+// paginate stops as soon as a page returns fewer than 50 items.
+func TestPaginate_StopsOnShortPage(t *testing.T) {
+	stub := newPageStub(t, map[int]int{1: 50, 2: 25})
+	srv := httptest.NewServer(stub.handler(encodeBare))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, "tok")
+	got, err := paginate[int](context.Background(), c, "/api/v1/things?page=%d&limit=50", "list things")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 75 {
+		t.Errorf("got %d items, want 75", len(got))
+	}
+	if want := []string{"1", "2"}; !slices.Equal(stub.requests, want) {
+		t.Errorf("requests = %v, want %v (must stop after short page)", stub.requests, want)
+	}
+}
+
+// paginateUntilEmpty ignores short pages and only stops on an empty page.
+// This is the contract that makes it safe against endpoints that post-filter
+// after the SQL LIMIT (e.g. the timeline endpoint).
+func TestPaginateUntilEmpty_IgnoresShortPagesStopsOnEmpty(t *testing.T) {
+	stub := newPageStub(t, map[int]int{1: 25, 2: 25, 3: 0})
+	srv := httptest.NewServer(stub.handler(encodeBare))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, "tok")
+	got, err := paginateUntilEmpty[int](context.Background(), c, "/api/v1/things?page=%d&limit=50", "list things")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 50 {
+		t.Errorf("got %d items, want 50", len(got))
+	}
+	if want := []string{"1", "2", "3"}; !slices.Equal(stub.requests, want) {
+		t.Errorf("requests = %v, want %v (must NOT stop on short page)", stub.requests, want)
+	}
+}
+
+// paginateWrapped decodes a wrapping object and uses the extract callback to
+// pull out the page items. Same EOF contract as paginate (stop on short).
+func TestPaginateWrapped_ExtractsAndStopsOnShortPage(t *testing.T) {
+	stub := newPageStub(t, map[int]int{1: 50, 2: 5})
+	srv := httptest.NewServer(stub.handler(encodeWrapped))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, "tok")
+	got, err := paginateWrapped(context.Background(), c,
+		"/api/v1/wrapped?page=%d&limit=50", "wrapped",
+		func(w *itemsWrapper) []int { return w.Items })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 55 {
+		t.Errorf("got %d items, want 55", len(got))
+	}
+	if got[0] != 1000 || got[49] != 1049 || got[50] != 2000 || got[54] != 2004 {
+		t.Errorf("unexpected items at boundaries: %v ... %v", got[:3], got[len(got)-3:])
+	}
+	if want := []string{"1", "2"}; !slices.Equal(stub.requests, want) {
+		t.Errorf("requests = %v, want %v", stub.requests, want)
+	}
+}
+
+// paginateWrappedUntilEmpty combines wrapped-object extraction with the
+// stop-on-empty contract: the helper must walk past short non-final pages
+// AND apply the extract callback on each one.
+func TestPaginateWrappedUntilEmpty_IgnoresShortPagesStopsOnEmpty(t *testing.T) {
+	stub := newPageStub(t, map[int]int{1: 10, 2: 10, 3: 0})
+	srv := httptest.NewServer(stub.handler(encodeWrapped))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, "tok")
+	got, err := paginateWrappedUntilEmpty(context.Background(), c,
+		"/api/v1/wrapped?page=%d&limit=50", "wrapped",
+		func(w *itemsWrapper) []int { return w.Items })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 20 {
+		t.Errorf("got %d items, want 20", len(got))
+	}
+	if want := []string{"1", "2", "3"}; !slices.Equal(stub.requests, want) {
+		t.Errorf("requests = %v, want %v (must NOT stop on short page)", stub.requests, want)
+	}
+}


### PR DESCRIPTION
We weren't paginating commit statuses meaning any commits with over 30 status events would be forever stuck not getting picked up by the merge queue

Marking as draft as untested