### PR TITLE
monitor: let a failed required check win over pending ones

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -71,19 +71,17 @@ func EvaluateChecks(statuses []pg.CheckStatus, requiredChecks []string) (CheckRe
 		statusMap[s.Context] = s
 	}
 
+	// Failures first: a failed required check decides the outcome even
+	// while other required checks are still pending.
 	for _, req := range requiredChecks {
 		cs, ok := statusMap[req]
-		if !ok {
-			return CheckWaiting, "", ""
-		}
-		switch cs.State {
-		case pg.CheckStateFailure, pg.CheckStateError:
+		if ok && (cs.State == pg.CheckStateFailure || cs.State == pg.CheckStateError) {
 			return CheckFailure, req, cs.TargetUrl
-		case pg.CheckStatePending:
-			return CheckWaiting, "", ""
-		case pg.CheckStateSuccess:
-			continue
-		default:
+		}
+	}
+	for _, req := range requiredChecks {
+		cs, ok := statusMap[req]
+		if !ok || cs.State != pg.CheckStateSuccess {
 			return CheckWaiting, "", ""
 		}
 	}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -206,3 +206,20 @@ func TestProcessCheckStatus_RetrySuccess(t *testing.T) {
 		t.Fatal("expected success after retry overwrites failure")
 	}
 }
+
+// A failed required check dequeues even while others are still pending.
+func TestEvaluateChecks_FailureWinsOverPending(t *testing.T) {
+	result, failed, url := monitor.EvaluateChecks(
+		[]pg.CheckStatus{
+			{Context: "buildbot/nix-eval", State: pg.CheckStatePending},
+			{Context: "buildbot/nix-build", State: pg.CheckStateFailure, TargetUrl: "https://ci/42"},
+		},
+		[]string{"buildbot/nix-eval", "buildbot/nix-build"},
+	)
+	if result != monitor.CheckFailure {
+		t.Fatalf("expected CheckFailure, got %v", result)
+	}
+	if failed != "buildbot/nix-build" || url != "https://ci/42" {
+		t.Fatalf("unexpected failed check %q url %q", failed, url)
+	}
+}


### PR DESCRIPTION

EvaluateChecks scanned required checks in order and returned
CheckWaiting at the first pending one, never reaching a failure
listed after it. A stuck pending check then blocked the queue
forever instead of dequeuing the failed PR.
