### PR TITLE
poller: skip merge-branch CI for already-rebased PRs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ times out, gitea-mq cancels automerge and posts a comment saying what went
 wrong.
 
 Only one PR is tested at a time per target branch. PRs targeting different
-branches get independent queues.
+branches get independent queues. If the head-of-queue PR already contains the
+current target tip, the merge-branch run is skipped and the PR's own green CI
+is accepted, since the merged tree would be identical (disable with
+`GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE=false` if your `gitea-mq/*` CI runs a
+larger suite than PR CI).
 
 ## Requirements
 
@@ -51,6 +55,7 @@ variables.
 | `GITEA_MQ_EXTERNAL_URL` | yes | - | URL where Gitea can reach this service (used for webhook auto-setup and commit status target URLs) |
 | `GITEA_MQ_POLL_INTERVAL` | no | `30s` | Automerge discovery poll interval |
 | `GITEA_MQ_CHECK_TIMEOUT` | no | `1h` | Timeout for required checks |
+| `GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE` | no | `true` | Skip the merge-branch CI run when a PR is already rebased onto the target branch tip (its own green CI already covers the merged tree) |
 | `GITEA_MQ_REQUIRED_CHECKS` | no | - | Fallback required CI contexts when branch protection has none (comma-separated) |
 | `GITEA_MQ_REFRESH_INTERVAL` | no | `10s` | Dashboard auto-refresh interval |
 | `GITEA_MQ_DISCOVERY_INTERVAL` | no | `5m` | How often to re-scan Gitea topics and GitHub installations |
@@ -233,6 +238,7 @@ Real-world deployments:
 | `externalUrl` | string | - | URL where Gitea can reach this service (for webhook auto-setup and commit status links) |
 | `pollInterval` | string | `30s` | Poll interval |
 | `checkTimeout` | string | `1h` | Check timeout |
+| `skipQueueIfUpToDate` | bool | `true` | Skip merge-branch CI for PRs already rebased onto the target tip |
 | `requiredChecks` | list of strings | `[]` | Fallback required CI contexts when branch protection has none |
 | `refreshInterval` | string | `10s` | Dashboard refresh interval |
 | `discoveryInterval` | string | `5m` | How often to re-discover repos by topic |

--- a/cmd/gitea-mq/main.go
+++ b/cmd/gitea-mq/main.go
@@ -113,14 +113,15 @@ func run() error {
 
 	// Create the repo registry — central coordination for managed repos.
 	reg := registry.New(ctx, &registry.Deps{
-		Forges:         forges,
-		Queue:          queueSvc,
-		WebhookSecret:  giteaWebhookSecret,
-		ExternalURL:    cfg.ExternalURL,
-		PollInterval:   cfg.PollInterval,
-		CheckTimeout:   cfg.CheckTimeout,
-		FallbackChecks: cfg.RequiredChecks,
-		SuccessTimeout: 5 * time.Minute,
+		Forges:              forges,
+		Queue:               queueSvc,
+		WebhookSecret:       giteaWebhookSecret,
+		ExternalURL:         cfg.ExternalURL,
+		PollInterval:        cfg.PollInterval,
+		CheckTimeout:        cfg.CheckTimeout,
+		FallbackChecks:      cfg.RequiredChecks,
+		SuccessTimeout:      5 * time.Minute,
+		SkipQueueIfUpToDate: cfg.SkipQueueIfUpToDate,
 	})
 
 	discTrigger := make(chan struct{}, 1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,16 +15,17 @@ type Config struct {
 	Gitea  *GiteaConfig  // nil if unconfigured
 	Github *GithubConfig // nil if unconfigured
 
-	DatabaseURL       string
-	ListenAddr        string
-	WebhookPath       string
-	ExternalURL       string
-	PollInterval      time.Duration
-	CheckTimeout      time.Duration
-	RequiredChecks    []string
-	RefreshInterval   time.Duration
-	DiscoveryInterval time.Duration
-	LogLevel          string
+	DatabaseURL         string
+	ListenAddr          string
+	WebhookPath         string
+	ExternalURL         string
+	PollInterval        time.Duration
+	CheckTimeout        time.Duration
+	RequiredChecks      []string
+	SkipQueueIfUpToDate bool
+	RefreshInterval     time.Duration
+	DiscoveryInterval   time.Duration
+	LogLevel            string
 }
 
 type GiteaConfig struct {
@@ -125,6 +126,11 @@ func Load() (*Config, error) {
 				cfg.RequiredChecks = append(cfg.RequiredChecks, c)
 			}
 		}
+	}
+
+	cfg.SkipQueueIfUpToDate, err = parseBool("GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE", true)
+	if err != nil {
+		return nil, err
 	}
 
 	cfg.LogLevel = envOrDefault("GITEA_MQ_LOG_LEVEL", "info")
@@ -249,6 +255,18 @@ func parseRepos(s string, kind forge.Kind) ([]forge.RepoRef, error) {
 		return nil, fmt.Errorf("no repos specified")
 	}
 	return repos, nil
+}
+
+func parseBool(envKey string, defaultVal bool) (bool, error) {
+	s := os.Getenv(envKey)
+	if s == "" {
+		return defaultVal, nil
+	}
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, fmt.Errorf("%s: invalid boolean %q", envKey, s)
+	}
+	return b, nil
 }
 
 func parseDurationOrDefault(envKey string, defaultVal time.Duration) (time.Duration, error) {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -158,6 +158,9 @@ type Forge interface {
 	CreateMergeBranch(ctx context.Context, owner, name, base, headSHA, branch string) (sha string, conflict bool, err error)
 	DeleteBranch(ctx context.Context, owner, name, branch string) error
 	ListBranches(ctx context.Context, owner, name string) ([]string, error)
+	// IsUpToDate reports whether headSHA already contains the tip of base
+	// (i.e. merging base into head would be a no-op).
+	IsUpToDate(ctx context.Context, owner, name, base, headSHA string) (bool, error)
 
 	CancelAutoMerge(ctx context.Context, owner, name string, number int64) error
 	Comment(ctx context.Context, owner, name string, number int64, body string) error

--- a/internal/forge/mock.go
+++ b/internal/forge/mock.go
@@ -30,6 +30,7 @@ type MockForge struct {
 	CreateMergeBranchFn func(ctx context.Context, owner, name, base, headSHA, branch string) (string, bool, error)
 	DeleteBranchFn      func(ctx context.Context, owner, name, branch string) error
 	ListBranchesFn      func(ctx context.Context, owner, name string) ([]string, error)
+	IsUpToDateFn        func(ctx context.Context, owner, name, base, headSHA string) (bool, error)
 	CancelAutoMergeFn   func(ctx context.Context, owner, name string, number int64) error
 	CommentFn           func(ctx context.Context, owner, name string, number int64, body string) error
 	EnsureRepoSetupFn   func(ctx context.Context, owner, name string, cfg SetupConfig) error
@@ -149,6 +150,14 @@ func (m *MockForge) ListBranches(ctx context.Context, owner, name string) ([]str
 		return m.ListBranchesFn(ctx, owner, name)
 	}
 	return nil, nil
+}
+
+func (m *MockForge) IsUpToDate(ctx context.Context, owner, name, base, headSHA string) (bool, error) {
+	m.record("IsUpToDate", owner, name, base, headSHA)
+	if m.IsUpToDateFn != nil {
+		return m.IsUpToDateFn(ctx, owner, name, base, headSHA)
+	}
+	return false, nil
 }
 
 func (m *MockForge) CancelAutoMerge(ctx context.Context, owner, name string, number int64) error {

--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -82,6 +82,12 @@ type BranchProtection struct {
 	StatusCheckContexts []string `json:"status_check_contexts"`
 }
 
+// Compare is the response from GET /repos/{owner}/{repo}/compare/{base}...{head}.
+// TotalCommits counts commits reachable from head but not from base.
+type Compare struct {
+	TotalCommits int `json:"total_commits"`
+}
+
 // MergeResult holds the outcome of merging two branches.
 type MergeResult struct {
 	SHA string // SHA of the merge commit on the new branch
@@ -202,6 +208,10 @@ type Client interface {
 	// DeleteBranch deletes a branch.
 	// DELETE /repos/{owner}/{repo}/branches/{branch}
 	DeleteBranch(ctx context.Context, owner, repo, name string) error
+
+	// CompareCommits returns the diff summary between base and head.
+	// GET /repos/{owner}/{repo}/compare/{base}...{head}
+	CompareCommits(ctx context.Context, owner, repo, base, head string) (*Compare, error)
 
 	// MergeBranches merges head into base and pushes the result as branchName.
 	// Returns the merge commit SHA, or a MergeConflictError if there are conflicts.

--- a/internal/gitea/forge.go
+++ b/internal/gitea/forge.go
@@ -155,6 +155,16 @@ func (f *giteaForge) CreateMergeBranch(ctx context.Context, owner, name, base, h
 	return res.SHA, false, nil
 }
 
+func (f *giteaForge) IsUpToDate(ctx context.Context, owner, name, base, headSHA string) (bool, error) {
+	// Gitea's compare only reports commits on the right side; swap so it
+	// counts commits on base that head is missing.
+	cmp, err := f.client.CompareCommits(ctx, owner, name, headSHA, base)
+	if err != nil {
+		return false, err
+	}
+	return cmp.TotalCommits == 0, nil
+}
+
 func (f *giteaForge) DeleteBranch(ctx context.Context, owner, name, branch string) error {
 	return f.client.DeleteBranch(ctx, owner, name, branch)
 }

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -357,6 +357,23 @@ func (c *HTTPClient) CreateBranch(ctx context.Context, owner, repo, name, target
 		fmt.Sprintf("create branch %s from %s in %s/%s", name, target, owner, repo))
 }
 
+// CompareCommits returns the commit count reachable from head but not base.
+// GET /repos/{owner}/{repo}/compare/{base}...{head}
+func (c *HTTPClient) CompareCommits(ctx context.Context, owner, repo, base, head string) (*Compare, error) {
+	resp, err := c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/repos/%s/%s/compare/%s...%s", owner, repo, base, head), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var cmp Compare
+	if err := c.decodeJSON(resp, &cmp); err != nil {
+		return nil, fmt.Errorf("compare %s...%s: %w", base, head, err)
+	}
+
+	return &cmp, nil
+}
+
 // DeleteBranch deletes a branch.
 // DELETE /repos/{owner}/{repo}/branches/{branch}
 func (c *HTTPClient) DeleteBranch(ctx context.Context, owner, repo, name string) error {

--- a/internal/gitea/mock.go
+++ b/internal/gitea/mock.go
@@ -33,6 +33,7 @@ type MockClient struct {
 	ListBranchesFn            func(ctx context.Context, owner, repo string) ([]Branch, error)
 	CreateBranchFn            func(ctx context.Context, owner, repo, name, target string) error
 	DeleteBranchFn            func(ctx context.Context, owner, repo, name string) error
+	CompareCommitsFn          func(ctx context.Context, owner, repo, base, head string) (*Compare, error)
 	MergeBranchesFn           func(ctx context.Context, owner, repo, base, head, branchName string) (*MergeResult, error)
 	ListBranchProtectionsFn   func(ctx context.Context, owner, repo string) ([]BranchProtection, error)
 	EditBranchProtectionFn    func(ctx context.Context, owner, repo, name string, opts EditBranchProtectionOpts) error
@@ -191,6 +192,16 @@ func (m *MockClient) DeleteBranch(ctx context.Context, owner, repo, name string)
 	}
 
 	return nil
+}
+
+func (m *MockClient) CompareCommits(ctx context.Context, owner, repo, base, head string) (*Compare, error) {
+	m.record("CompareCommits", owner, repo, base, head)
+
+	if m.CompareCommitsFn != nil {
+		return m.CompareCommitsFn(ctx, owner, repo, base, head)
+	}
+
+	return &Compare{}, nil
 }
 
 func (m *MockClient) MergeBranches(ctx context.Context, owner, repo, base, head, branchName string) (*MergeResult, error) {

--- a/internal/github/forge.go
+++ b/internal/github/forge.go
@@ -209,6 +209,19 @@ func (f *githubForge) CreateMergeBranch(ctx context.Context, owner, name, base, 
 	return commit.GetSHA(), false, nil
 }
 
+func (f *githubForge) IsUpToDate(ctx context.Context, owner, name, base, headSHA string) (bool, error) {
+	c, err := f.app.ClientForRepo(owner, name)
+	if err != nil {
+		return false, err
+	}
+	// per_page=1: we only need behind_by, not the commit list.
+	cmp, _, err := c.Repositories.CompareCommits(ctx, owner, name, base, headSHA, &gh.ListOptions{PerPage: 1})
+	if err != nil {
+		return false, fmt.Errorf("compare %s...%s: %w", base, headSHA, err)
+	}
+	return cmp.GetBehindBy() == 0, nil
+}
+
 func (f *githubForge) DeleteBranch(ctx context.Context, owner, name, branch string) error {
 	c, err := f.app.ClientForRepo(owner, name)
 	if err != nil {

--- a/internal/github/forge_test.go
+++ b/internal/github/forge_test.go
@@ -129,6 +129,20 @@ func TestForge_GetCheckStates_MapsRunsAndExcludesSelf(t *testing.T) {
 	}
 }
 
+func TestForge_IsUpToDate(t *testing.T) {
+	srv, f := newTestForge(t)
+	repo := srv.Repo("org", "app")
+	repo.BehindBy["main...sha-behind"] = 2
+
+	ctx := context.Background()
+	if ok, err := f.IsUpToDate(ctx, "org", "app", "main", "sha-rebased"); err != nil || !ok {
+		t.Fatalf("rebased: ok=%v err=%v, want true,nil", ok, err)
+	}
+	if ok, err := f.IsUpToDate(ctx, "org", "app", "main", "sha-behind"); err != nil || ok {
+		t.Fatalf("behind: ok=%v err=%v, want false,nil", ok, err)
+	}
+}
+
 // 409 from the merge endpoint must surface as (conflict=true, err=nil).
 func TestForge_CreateMergeBranch_Conflict(t *testing.T) {
 	srv, f := newTestForge(t)

--- a/internal/github/ghfake/server.go
+++ b/internal/github/ghfake/server.go
@@ -68,6 +68,9 @@ type Repo struct {
 	Refs      map[string]string // branch -> sha
 	CheckRuns map[string][]*CheckRun
 	Rulesets  []*Ruleset
+	// BehindBy["base...head"] feeds GET /compare/{base}...{head}.behind_by.
+	// Missing entries default to 0 (head up to date with base).
+	BehindBy map[string]int
 	// ConflictOn[head] makes POST /merges with that head return 409.
 	ConflictOn map[string]bool
 	// Settings tracks PATCH /repos/{o}/{r} keys.
@@ -158,6 +161,7 @@ func (s *Server) AddRepo(owner, name string) *Repo {
 		PRs:            map[int64]*PR{},
 		Refs:           map[string]string{"main": "sha-main"},
 		CheckRuns:      map[string][]*CheckRun{},
+		BehindBy:       map[string]int{},
 		ConflictOn:     map[string]bool{},
 		Settings:       map[string]any{},
 		RequiredChecks: map[string][]string{},
@@ -235,6 +239,7 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE "+apiV3+"/repos/{o}/{r}/git/refs/{ref...}", s.hDeleteRef)
 	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/branches", s.hListBranches)
 	mux.HandleFunc("POST "+apiV3+"/repos/{o}/{r}/merges", s.hMerge)
+	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/compare/{basehead...}", s.hCompare)
 
 	// Rules / rulesets.
 	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/rules/branches/{b}", s.hRulesForBranch)
@@ -667,6 +672,18 @@ func (s *Server) hMerge(w http.ResponseWriter, r *http.Request) {
 	mergeSHA := fmt.Sprintf("merge(%s,%s)", rp.Refs[body.Base], body.Head)
 	rp.Refs[body.Base] = mergeSHA
 	writeJSON(w, 201, map[string]any{"sha": mergeSHA})
+}
+
+func (s *Server) hCompare(w http.ResponseWriter, r *http.Request) {
+	rp, ok := s.repo(r)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	s.mu.Lock()
+	behind := rp.BehindBy[r.PathValue("basehead")]
+	s.mu.Unlock()
+	writeJSON(w, 200, map[string]any{"behind_by": behind, "ahead_by": 0, "commits": []any{}})
 }
 
 // --- handlers: rules ---

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -32,6 +32,9 @@ type Deps struct {
 	// SuccessTimeout is how long a PR may sit in "success" without merging
 	// before we assume the forge's auto-merge failed.
 	SuccessTimeout time.Duration
+	// SkipQueueIfUpToDate skips the merge-branch CI run when the head PR
+	// already contains the target tip: its own green CI covered the same tree.
+	SkipQueueIfUpToDate bool
 	// CheckTimeout is how long a PR may sit in "testing" without a check
 	// status before we abandon it. Without this, a CI server that loses a
 	// build (e.g. a restart) leaves the head-of-queue stuck forever since
@@ -337,6 +340,10 @@ func startQueuedHeads(ctx context.Context, deps *Deps, result *PollResult) {
 			continue
 		}
 
+		if deps.SkipQueueIfUpToDate && tryFastForwardSuccess(ctx, deps, result, head) {
+			continue
+		}
+
 		startResult, err := merge.StartTesting(ctx, deps.Forge, deps.Queue, deps.Owner, deps.Repo, deps.RepoID, head, deps.ExternalURL)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("start testing for PR #%d: %w", head.PrNumber, err))
@@ -350,6 +357,32 @@ func startQueuedHeads(ctx context.Context, deps *Deps, result *PollResult) {
 			slog.Info("started testing for head-of-queue", "pr", head.PrNumber, "branch", startResult.MergeBranchName)
 		}
 	}
+}
+
+// tryFastForwardSuccess promotes head straight to success when it already
+// contains the target branch tip. Returns true when the entry was handled.
+// Compare errors fall through to StartTesting so a flaky API never stalls
+// the queue.
+func tryFastForwardSuccess(ctx context.Context, deps *Deps, result *PollResult, head *pg.QueueEntry) bool {
+	upToDate, err := deps.Forge.IsUpToDate(ctx, deps.Owner, deps.Repo, head.TargetBranch, head.PrHeadSha)
+	if err != nil {
+		slog.Warn("up-to-date check failed, falling back to merge branch", "pr", head.PrNumber, "error", err)
+		return false
+	}
+	if !upToDate {
+		return false
+	}
+
+	targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, head.PrNumber)
+	_ = deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, head.PrHeadSha, forge.MQStatus{
+		State: pg.CheckStateSuccess, Description: "Already up to date with target branch", TargetURL: targetURL,
+	})
+	if err := deps.Queue.UpdateState(ctx, deps.RepoID, head.PrNumber, pg.EntryStateSuccess); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("update state to success for PR #%d: %w", head.PrNumber, err))
+		return true
+	}
+	slog.Info("skipped merge-branch testing: PR already up to date with target", "pr", head.PrNumber)
+	return true
 }
 
 // Run starts the polling loop. The first poll happens immediately.

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -52,6 +52,82 @@ func cancelledTimeline() []gitea.TimelineComment {
 	}
 }
 
+// With SkipQueueIfUpToDate, a PR already rebased onto base goes straight to
+// success: its own CI is green and the merged tree would be identical.
+func TestPollOnce_SkipQueueIfUpToDate(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupPollerTest(t)
+	deps.SkipQueueIfUpToDate = true
+
+	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
+		return []gitea.PR{makePR(42, "sha42", "main")}, nil
+	}
+	mock.GetPRTimelineFn = func(_ context.Context, _, _ string, _ int64) ([]gitea.TimelineComment, error) {
+		return automergeTimeline(), nil
+	}
+	mock.CompareCommitsFn = func(_ context.Context, _, _, base, head string) (*gitea.Compare, error) {
+		if base != "sha42" || head != "main" {
+			t.Errorf("compare called with base=%q head=%q, want sha42...main", base, head)
+		}
+		return &gitea.Compare{TotalCommits: 0}, nil
+	}
+	mock.MergeBranchesFn = func(_ context.Context, _, _, _, _, _ string) (*gitea.MergeResult, error) {
+		t.Fatal("MergeBranches must not be called when PR is up-to-date")
+		return nil, nil
+	}
+
+	result, err := poller.PollOnce(ctx, deps)
+	if err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("errors: %v", result.Errors)
+	}
+
+	entry, _ := svc.GetEntry(ctx, repoID, 42)
+	if entry == nil || entry.State != pg.EntryStateSuccess {
+		t.Fatalf("expected entry in success state, got %+v", entry)
+	}
+
+	var sawSuccess bool
+	for _, c := range mock.CallsTo("CreateCommitStatus") {
+		if s := c.Args[3].(gitea.CommitStatus); s.Context == "gitea-mq" && s.State == "success" {
+			sawSuccess = true
+		}
+	}
+	if !sawSuccess {
+		t.Error("expected gitea-mq success status on PR head")
+	}
+}
+
+// SkipQueueIfUpToDate must not short-circuit when the PR is behind base:
+// the merge branch is still required so CI sees the combined tree.
+func TestPollOnce_SkipQueueIfUpToDate_BehindBase(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupPollerTest(t)
+	deps.SkipQueueIfUpToDate = true
+
+	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
+		return []gitea.PR{makePR(42, "sha42", "main")}, nil
+	}
+	mock.GetPRTimelineFn = func(_ context.Context, _, _ string, _ int64) ([]gitea.TimelineComment, error) {
+		return automergeTimeline(), nil
+	}
+	mock.CompareCommitsFn = func(_ context.Context, _, _, _, _ string) (*gitea.Compare, error) {
+		return &gitea.Compare{TotalCommits: 3}, nil
+	}
+
+	if _, err := poller.PollOnce(ctx, deps); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+
+	entry, _ := svc.GetEntry(ctx, repoID, 42)
+	if entry == nil || entry.State != pg.EntryStateTesting {
+		t.Fatalf("expected entry in testing state, got %+v", entry)
+	}
+	if len(mock.CallsTo("MergeBranches")) != 1 {
+		t.Error("expected MergeBranches call for behind-base PR")
+	}
+}
+
 // Happy path: a fresh auto-merge PR is discovered, queued, and immediately
 // promoted to testing with the right commit statuses.
 func TestPollOnce_NewAutomergePR_Enqueues(t *testing.T) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -26,14 +26,15 @@ type ManagedRepo struct {
 }
 
 type Deps struct {
-	Forges         *forge.Set
-	Queue          *queue.Service
-	WebhookSecret  string
-	ExternalURL    string
-	PollInterval   time.Duration
-	CheckTimeout   time.Duration
-	FallbackChecks []string
-	SuccessTimeout time.Duration
+	Forges              *forge.Set
+	Queue               *queue.Service
+	WebhookSecret       string
+	ExternalURL         string
+	PollInterval        time.Duration
+	CheckTimeout        time.Duration
+	FallbackChecks      []string
+	SuccessTimeout      time.Duration
+	SkipQueueIfUpToDate bool
 }
 
 // RepoRegistry manages the set of active repos. Thread-safe for concurrent
@@ -123,16 +124,17 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 	}
 
 	pollerDeps := &poller.Deps{
-		Forge:          f,
-		Queue:          r.deps.Queue,
-		RepoID:         repo.ID,
-		Owner:          ref.Owner,
-		Repo:           ref.Name,
-		Trigger:        trigger,
-		ExternalURL:    r.deps.ExternalURL,
-		FallbackChecks: r.deps.FallbackChecks,
-		SuccessTimeout: r.deps.SuccessTimeout,
-		CheckTimeout:   r.deps.CheckTimeout,
+		Forge:               f,
+		Queue:               r.deps.Queue,
+		RepoID:              repo.ID,
+		Owner:               ref.Owner,
+		Repo:                ref.Name,
+		Trigger:             trigger,
+		ExternalURL:         r.deps.ExternalURL,
+		FallbackChecks:      r.deps.FallbackChecks,
+		SuccessTimeout:      r.deps.SuccessTimeout,
+		CheckTimeout:        r.deps.CheckTimeout,
+		SkipQueueIfUpToDate: r.deps.SkipQueueIfUpToDate,
 	}
 	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval)
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -120,6 +120,12 @@ in
       description = "Timeout for required checks.";
     };
 
+    skipQueueIfUpToDate = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Skip the merge-branch CI run for PRs already rebased onto the target branch tip.";
+    };
+
     requiredChecks = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -241,6 +247,7 @@ in
         GITEA_MQ_EXTERNAL_URL = cfg.externalUrl;
         GITEA_MQ_POLL_INTERVAL = cfg.pollInterval;
         GITEA_MQ_CHECK_TIMEOUT = cfg.checkTimeout;
+        GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE = lib.boolToString cfg.skipQueueIfUpToDate;
         GITEA_MQ_REFRESH_INTERVAL = cfg.refreshInterval;
         GITEA_MQ_DISCOVERY_INTERVAL = cfg.discoveryInterval;
         GITEA_MQ_LOG_LEVEL = cfg.logLevel;

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -77,6 +77,9 @@ pkgs.testers.runNixOSTest {
         pollInterval = "5s";
         discoveryInterval = "5s";
         checkTimeout = "5m";
+        # The test asserts the full merge-branch flow; the only PR it opens is
+        # already up-to-date with main, so the default skip would bypass it.
+        skipQueueIfUpToDate = false;
         logLevel = "debug";
       };
 


### PR DESCRIPTION
When a PR at the head of the queue already contains the current target-branch tip, the merge result is tree-identical to the PR head commit. That commit's CI was already green when the PR was enqueued, so creating a gitea-mq/* branch and running CI a second time only costs CI minutes and queue latency without changing the outcome.

Add GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE (default on) which checks this via the forge compare API and, when satisfied, sets the gitea-mq status to success and transitions the entry directly to the success state. The check happens at promotion time, so a base that moved while the PR was queued still forces a full merge-branch run. Compare-API errors fall through to the normal path so a flaky endpoint never stalls the queue.

Set the option to false if CI on gitea-mq/* runs a different suite than PR branches and the merge-branch run is therefore the real gate.