### PR TITLE
Reduce forge API usage: idle-gating + ETag caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ variables.
 | `GITEA_MQ_LISTEN_ADDR` | no | `:8080` | HTTP listen address |
 | `GITEA_MQ_WEBHOOK_PATH` | no | `/webhook` | Legacy alias for the Gitea webhook endpoint (the canonical path is `/webhook/gitea`) |
 | `GITEA_MQ_EXTERNAL_URL` | yes | - | URL where Gitea can reach this service (used for webhook auto-setup and commit status target URLs) |
-| `GITEA_MQ_POLL_INTERVAL` | no | `30s` | Automerge discovery poll interval |
+| `GITEA_MQ_POLL_INTERVAL` | no | `30s` | Reconcile poll interval for repos with active queue work |
+| `GITEA_MQ_IDLE_POLL_INTERVAL` | no | `15m` | Reconcile poll interval for idle repos (no active queue entries). Idle repos are driven by webhooks; this periodic poll is only a safety net for deliveries missed while the service was down. Keeping it long bounds forge API usage to the number of repos with live queues rather than all managed repos |
 | `GITEA_MQ_CHECK_TIMEOUT` | no | `1h` | Timeout for required checks |
 | `GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE` | no | `true` | Skip the merge-branch CI run when a PR is already rebased onto the target branch tip (its own green CI already covers the merged tree) |
 | `GITEA_MQ_REQUIRED_CHECKS` | no | - | Fallback required CI contexts when branch protection has none (comma-separated) |

--- a/cmd/gitea-mq/main.go
+++ b/cmd/gitea-mq/main.go
@@ -60,6 +60,7 @@ func run() error {
 		"gitea", cfg.Gitea != nil,
 		"github", cfg.Github != nil,
 		"poll_interval", cfg.PollInterval,
+		"idle_poll_interval", cfg.IdlePollInterval,
 		"check_timeout", cfg.CheckTimeout,
 		"batch_max", cfg.BatchMax,
 	)
@@ -119,6 +120,7 @@ func run() error {
 		WebhookSecret:       giteaWebhookSecret,
 		ExternalURL:         cfg.ExternalURL,
 		PollInterval:        cfg.PollInterval,
+		IdlePollInterval:    cfg.IdlePollInterval,
 		CheckTimeout:        cfg.CheckTimeout,
 		FallbackChecks:      cfg.RequiredChecks,
 		SuccessTimeout:      5 * time.Minute,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	WebhookPath         string
 	ExternalURL         string
 	PollInterval        time.Duration
+	IdlePollInterval    time.Duration
 	CheckTimeout        time.Duration
 	RequiredChecks      []string
 	SkipQueueIfUpToDate bool
@@ -99,6 +100,12 @@ func Load() (*Config, error) {
 	}
 
 	cfg.PollInterval, err = parseDurationOrDefault("GITEA_MQ_POLL_INTERVAL", 30*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	// Idle repos are driven by webhooks; this periodic reconcile is only a
+	// safety net for deliveries missed during downtime, so it can run rarely.
+	cfg.IdlePollInterval, err = parseDurationOrDefault("GITEA_MQ_IDLE_POLL_INTERVAL", 15*time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,6 +163,37 @@ func TestLoad_GithubPrivateKeyFile(t *testing.T) {
 	}
 }
 
+func TestLoad_IdlePollIntervalDefaultAndOverride(t *testing.T) {
+	setEnv(t, with(map[string]string{
+		"GITEA_MQ_GITEA_URL":      "https://gitea.example.com/",
+		"GITEA_MQ_GITEA_TOKEN":    "tok",
+		"GITEA_MQ_WEBHOOK_SECRET": "sec",
+		"GITEA_MQ_REPOS":          "org/app",
+	}))
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.IdlePollInterval != 15*time.Minute {
+		t.Errorf("IdlePollInterval = %v, want 15m default", cfg.IdlePollInterval)
+	}
+
+	setEnv(t, with(map[string]string{
+		"GITEA_MQ_GITEA_URL":          "https://gitea.example.com/",
+		"GITEA_MQ_GITEA_TOKEN":        "tok",
+		"GITEA_MQ_WEBHOOK_SECRET":     "sec",
+		"GITEA_MQ_REPOS":              "org/app",
+		"GITEA_MQ_IDLE_POLL_INTERVAL": "3m",
+	}))
+	cfg, err = Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.IdlePollInterval != 3*time.Minute {
+		t.Errorf("IdlePollInterval = %v, want 3m", cfg.IdlePollInterval)
+	}
+}
+
 func TestLoad_GithubPollIntervalOverride(t *testing.T) {
 	setEnv(t, with(map[string]string{
 		"GITEA_MQ_GITHUB_APP_ID":         "1",

--- a/internal/github/app.go
+++ b/internal/github/app.go
@@ -40,7 +40,12 @@ func NewApp(appID int64, privateKey []byte, baseURL string) (*App, error) {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
-	atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, privateKey)
+	// Wrap the base transport in an ETag cache so unchanged GETs revalidate
+	// with a 304, which GitHub does not charge against the rate limit. Both
+	// the app client and every installation client derive from this transport
+	// (installation clients reuse atr.tr), so all reads are covered.
+	caching := newETagCache(http.DefaultTransport, 4096)
+	atr, err := ghinstallation.NewAppsTransport(caching, appID, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("github app transport: %w", err)
 	}

--- a/internal/github/etagcache.go
+++ b/internal/github/etagcache.go
@@ -1,0 +1,118 @@
+package github
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// etagCache revalidates GET responses with If-None-Match. GitHub does not
+// charge a 304 against the primary rate limit, so unchanged reads are free. On
+// a 304 it replays the cached body, so upstream always sees a 200.
+type etagCache struct {
+	next    http.RoundTripper
+	maxSize int
+
+	mu      sync.Mutex
+	entries map[string]*etagEntry
+}
+
+type etagEntry struct {
+	etag   string
+	body   []byte
+	header http.Header
+	status int
+}
+
+func newETagCache(next http.RoundTripper, maxSize int) *etagCache {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return &etagCache{next: next, maxSize: maxSize, entries: map[string]*etagEntry{}}
+}
+
+// cacheKey includes Accept because it selects the media type: different
+// representations of the same URL must not share an entry.
+func cacheKey(req *http.Request) string {
+	return req.Method + " " + req.URL.String() + " " + req.Header.Get("Accept")
+}
+
+func (c *etagCache) get(key string) *etagEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.entries[key]
+}
+
+func (c *etagCache) put(key string, e *etagEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Drop everything when full: entries refill for free (a 304), so a coarse
+	// reset beats tracking LRU state.
+	if len(c.entries) >= c.maxSize {
+		c.entries = map[string]*etagEntry{}
+	}
+	c.entries[key] = e
+}
+
+func (c *etagCache) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodGet {
+		return c.next.RoundTrip(req)
+	}
+
+	key := cacheKey(req)
+	cached := c.get(key)
+	if cached != nil {
+		req = req.Clone(req.Context())
+		req.Header.Set("If-None-Match", cached.etag)
+	}
+
+	resp, err := c.next.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotModified && cached != nil {
+		_ = resp.Body.Close()
+		return cached.response(req, resp.Header), nil
+	}
+
+	etag := resp.Header.Get("ETag")
+	if resp.StatusCode == http.StatusOK && etag != "" {
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		c.put(key, &etagEntry{
+			etag:   etag,
+			body:   body,
+			header: resp.Header.Clone(),
+			status: resp.StatusCode,
+		})
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	return resp, nil
+}
+
+// response rebuilds a *http.Response from a cached entry, overlaying the 304's
+// live rate-limit headers so downstream accounting stays accurate.
+func (e *etagEntry) response(req *http.Request, liveHeader http.Header) *http.Response {
+	h := e.header.Clone()
+	for k, v := range liveHeader {
+		if strings.HasPrefix(http.CanonicalHeaderKey(k), "X-Ratelimit") {
+			h[http.CanonicalHeaderKey(k)] = v
+		}
+	}
+	return &http.Response{
+		Status:     http.StatusText(e.status),
+		StatusCode: e.status,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewReader(e.body)),
+		Request:    req,
+	}
+}

--- a/internal/github/etagcache_test.go
+++ b/internal/github/etagcache_test.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// countingTransport records how many requests reached the origin and echoes a
+// fixed ETag so the cache can revalidate.
+type countingTransport struct {
+	origin int
+	body   string
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.origin++
+	rec := httptest.NewRecorder()
+	if req.Header.Get("If-None-Match") == `"v1"` {
+		rec.WriteHeader(http.StatusNotModified)
+		rec.Header().Set("X-RateLimit-Remaining", "5000")
+		resp := rec.Result()
+		resp.Request = req
+		return resp, nil
+	}
+	rec.Header().Set("ETag", `"v1"`)
+	rec.WriteHeader(http.StatusOK)
+	_, _ = rec.WriteString(t.body)
+	resp := rec.Result()
+	resp.Request = req
+	return resp, nil
+}
+
+func TestETagCache_RevalidatesAndServesCachedBody(t *testing.T) {
+	origin := &countingTransport{body: "hello"}
+	c := newETagCache(origin, 16)
+
+	do := func() (int, string) {
+		req, _ := http.NewRequest(http.MethodGet, "https://api.github.com/x", nil)
+		resp, err := c.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return resp.StatusCode, string(b)
+	}
+
+	// First call populates the cache from a 200.
+	if code, body := do(); code != 200 || body != "hello" {
+		t.Fatalf("first call = %d %q, want 200 hello", code, body)
+	}
+	// Second call revalidates; origin returns 304 but caller still sees the body.
+	if code, body := do(); code != 200 || body != "hello" {
+		t.Fatalf("second call = %d %q, want 200 hello (from cache)", code, body)
+	}
+	if origin.origin != 2 {
+		t.Fatalf("origin hit %d times, want 2 (both revalidations reach GitHub)", origin.origin)
+	}
+}
+
+func TestETagCache_SendsIfNoneMatch(t *testing.T) {
+	var lastINM string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		lastINM = req.Header.Get("If-None-Match")
+		rec := httptest.NewRecorder()
+		rec.Header().Set("ETag", `"v1"`)
+		rec.WriteHeader(http.StatusOK)
+		resp := rec.Result()
+		resp.Request = req
+		return resp, nil
+	})
+	c := newETagCache(rt, 16)
+
+	req1, _ := http.NewRequest(http.MethodGet, "https://api.github.com/y", nil)
+	resp1, _ := c.RoundTrip(req1)
+	_ = resp1.Body.Close()
+	if lastINM != "" {
+		t.Fatalf("first request sent If-None-Match=%q, want empty", lastINM)
+	}
+
+	req2, _ := http.NewRequest(http.MethodGet, "https://api.github.com/y", nil)
+	resp2, _ := c.RoundTrip(req2)
+	_ = resp2.Body.Close()
+	if lastINM != `"v1"` {
+		t.Fatalf("second request If-None-Match=%q, want \"v1\"", lastINM)
+	}
+}
+
+// POST must bypass the cache entirely.
+func TestETagCache_SkipsNonGET(t *testing.T) {
+	var inm string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		inm = req.Header.Get("If-None-Match")
+		rec := httptest.NewRecorder()
+		rec.Header().Set("ETag", `"v1"`)
+		rec.WriteHeader(http.StatusOK)
+		resp := rec.Result()
+		resp.Request = req
+		return resp, nil
+	})
+	c := newETagCache(rt, 16)
+
+	for range 2 {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.github.com/z", nil)
+		resp, _ := c.RoundTrip(req)
+		_ = resp.Body.Close()
+	}
+	if inm != "" {
+		t.Fatalf("POST sent If-None-Match=%q, want empty (not cached)", inm)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -511,9 +511,21 @@ func tryFastForwardSuccess(ctx context.Context, deps *Deps, result *PollResult, 
 	return true
 }
 
+// hasActiveWork reports whether the repo has live queue state. It only reads
+// the local DB, so idle repos can be skipped without spending forge API quota.
+func hasActiveWork(ctx context.Context, deps *Deps) bool {
+	entries, err := deps.Queue.ListActiveEntries(ctx, deps.RepoID)
+	if err != nil {
+		// Fail open: keep reconciling rather than stall on a transient DB error.
+		slog.Warn("active-work check failed, polling anyway", "owner", deps.Owner, "repo", deps.Repo, "error", err)
+		return true
+	}
+	return len(entries) > 0
+}
+
 // Run starts the polling loop. The first poll happens immediately.
-func Run(ctx context.Context, deps *Deps, interval time.Duration) {
-	slog.Info("poller started", "owner", deps.Owner, "repo", deps.Repo, "interval", interval)
+func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) {
+	slog.Info("poller started", "owner", deps.Owner, "repo", deps.Repo, "interval", interval, "idle_interval", idleInterval)
 
 	// periodic ticks log paused/issue diagnostics; the initial and
 	// webhook-triggered polls stay quiet to avoid log noise on bursts.
@@ -536,8 +548,14 @@ func Run(ctx context.Context, deps *Deps, interval time.Duration) {
 
 	doPoll(false)
 
+	// Idle repos reconcile at idleInterval instead of every tick, keeping
+	// periodic forge traffic proportional to repos with live queue work.
+	if idleInterval < interval {
+		idleInterval = interval
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	lastFull := time.Now()
 
 	for {
 		select {
@@ -546,8 +564,13 @@ func Run(ctx context.Context, deps *Deps, interval time.Duration) {
 			return
 		case <-deps.Trigger:
 			doPoll(false)
+			lastFull = time.Now()
 		case <-ticker.C:
+			if !hasActiveWork(ctx, deps) && time.Since(lastFull) < idleInterval {
+				continue
+			}
 			doPoll(true)
+			lastFull = time.Now()
 		}
 	}
 }

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -44,6 +44,10 @@ type Deps struct {
 	// Batch enables bors-style batching when non-nil. The legacy single-PR
 	// path is taken when nil so BATCH_MAX=1 stays byte-for-byte unchanged.
 	Batch *batch.Engine
+	// IdleGating lets the periodic reconcile skip repos with no live queue
+	// work. Safe only on forges that deliver CI status via webhooks (GitHub);
+	// must stay false for Gitea/Forgejo, which have no commit-status webhook.
+	IdleGating bool
 }
 
 type PollResult struct {
@@ -523,9 +527,10 @@ func hasActiveWork(ctx context.Context, deps *Deps) bool {
 	return len(entries) > 0
 }
 
-// Run starts the polling loop. The first poll happens immediately.
+// Run starts the polling loop. The first poll happens immediately. idleInterval
+// throttles reconciles for idle repos only when deps.IdleGating is set.
 func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) {
-	slog.Info("poller started", "owner", deps.Owner, "repo", deps.Repo, "interval", interval, "idle_interval", idleInterval)
+	slog.Info("poller started", "owner", deps.Owner, "repo", deps.Repo, "interval", interval, "idle_interval", idleInterval, "idle_gating", deps.IdleGating)
 
 	// periodic ticks log paused/issue diagnostics; the initial and
 	// webhook-triggered polls stay quiet to avoid log noise on bursts.
@@ -566,7 +571,7 @@ func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) 
 			doPoll(false)
 			lastFull = time.Now()
 		case <-ticker.C:
-			if !hasActiveWork(ctx, deps) && time.Since(lastFull) < idleInterval {
+			if deps.IdleGating && !hasActiveWork(ctx, deps) && time.Since(lastFull) < idleInterval {
 				continue
 			}
 			doPoll(true)

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -546,3 +546,69 @@ func TestPollOnce_GiteaUnavailable_Pauses(t *testing.T) {
 		t.Fatalf("expected 1 error, got %d", len(result.Errors))
 	}
 }
+
+// An idle repo must not hit the forge on every tick: only the startup
+// reconcile runs until the idle interval elapses.
+func TestRun_IdleRepoSkipsPeriodicPoll(t *testing.T) {
+	deps, mock, _, ctx, _ := setupPollerTest(t)
+
+	var listed int
+	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
+		listed++
+		return nil, nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		// Fast tick, long idle interval: idle repo polls only at startup.
+		poller.Run(runCtx, deps, 5*time.Millisecond, time.Hour)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if listed != 1 {
+		t.Fatalf("idle repo polled forge %d times, want 1 (startup only)", listed)
+	}
+}
+
+// A trigger (webhook) must reconcile an idle repo even before the idle
+// interval elapses; this is how an auto-merge PR gone green gets enqueued.
+func TestRun_TriggerPollsIdleRepo(t *testing.T) {
+	deps, mock, _, ctx, _ := setupPollerTest(t)
+
+	trigger := make(chan struct{}, 1)
+	deps.Trigger = trigger
+
+	var listed int
+	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
+		listed++
+		return nil, nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		poller.Run(runCtx, deps, time.Hour, time.Hour)
+		close(done)
+	}()
+
+	// Let the startup poll settle, then fire a webhook-style trigger.
+	time.Sleep(20 * time.Millisecond)
+	trigger <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Startup poll + triggered poll.
+	if listed != 2 {
+		t.Fatalf("triggered idle repo polled forge %d times, want 2", listed)
+	}
+}

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -551,6 +551,7 @@ func TestPollOnce_GiteaUnavailable_Pauses(t *testing.T) {
 // reconcile runs until the idle interval elapses.
 func TestRun_IdleRepoSkipsPeriodicPoll(t *testing.T) {
 	deps, mock, _, ctx, _ := setupPollerTest(t)
+	deps.IdleGating = true
 
 	var listed int
 	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
@@ -577,10 +578,43 @@ func TestRun_IdleRepoSkipsPeriodicPoll(t *testing.T) {
 	}
 }
 
+// Without idle-gating (Gitea/Forgejo, which have no status webhook) an idle
+// repo must keep polling every tick: the poll is the only way to notice a PR
+// went green. Regression guard for the forgejo integration test.
+func TestRun_NoIdleGatingPollsEveryTick(t *testing.T) {
+	deps, mock, _, ctx, _ := setupPollerTest(t)
+	// deps.IdleGating stays false (the gitea default).
+
+	var listed int
+	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
+		listed++
+		return nil, nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		poller.Run(runCtx, deps, 5*time.Millisecond, time.Hour)
+		close(done)
+	}()
+
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Startup poll plus several periodic polls despite the repo being idle.
+	if listed < 3 {
+		t.Fatalf("idle repo without gating polled %d times, want many", listed)
+	}
+}
+
 // A trigger (webhook) must reconcile an idle repo even before the idle
 // interval elapses; this is how an auto-merge PR gone green gets enqueued.
 func TestRun_TriggerPollsIdleRepo(t *testing.T) {
 	deps, mock, _, ctx, _ := setupPollerTest(t)
+	deps.IdleGating = true
 
 	trigger := make(chan struct{}, 1)
 	deps.Trigger = trigger

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -32,6 +32,7 @@ type Deps struct {
 	WebhookSecret       string
 	ExternalURL         string
 	PollInterval        time.Duration
+	IdlePollInterval    time.Duration
 	CheckTimeout        time.Duration
 	FallbackChecks      []string
 	SuccessTimeout      time.Duration
@@ -170,7 +171,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		SkipQueueIfUpToDate: r.deps.SkipQueueIfUpToDate,
 		Batch:               batchEngine,
 	}
-	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval)
+	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval, r.deps.IdlePollInterval)
 
 	r.mu.Lock()
 	if _, exists := r.repos[key]; !exists {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -170,6 +170,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		CheckTimeout:        r.deps.CheckTimeout,
 		SkipQueueIfUpToDate: r.deps.SkipQueueIfUpToDate,
 		Batch:               batchEngine,
+		IdleGating:          f.Kind() == forge.KindGithub,
 	}
 	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval, r.deps.IdlePollInterval)
 

--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -67,6 +67,10 @@ func GithubHandler(secret []byte, repos RepoLookup, queueSvc *queue.Service, tri
 				Description: cr.GetOutput().GetSummary(),
 				TargetURL:   cr.GetDetailsURL(),
 			})
+			// Green CI may make an auto-merge PR enqueuable; the poller decides.
+			if rm.TriggerPoll != nil {
+				rm.TriggerPoll()
+			}
 
 		case *gh.StatusEvent:
 			if forge.IsOwnContext(e.GetContext()) {
@@ -81,6 +85,9 @@ func GithubHandler(secret []byte, repos RepoLookup, queueSvc *queue.Service, tri
 				Description: e.GetDescription(),
 				TargetURL:   e.GetTargetURL(),
 			})
+			if rm.TriggerPoll != nil {
+				rm.TriggerPoll()
+			}
 
 		case *gh.InstallationEvent, *gh.InstallationRepositoriesEvent:
 			if triggerDiscovery != nil {

--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mic92/gitea-mq/internal/forge"
 	"github.com/Mic92/gitea-mq/internal/github"
 	"github.com/Mic92/gitea-mq/internal/queue"
+	"github.com/Mic92/gitea-mq/internal/store/pg"
 )
 
 // prTriggerActions are the pull_request actions that change the desired queue
@@ -62,15 +63,13 @@ func GithubHandler(secret []byte, repos RepoLookup, queueSvc *queue.Service, tri
 			if !ok {
 				break
 			}
-			routeCheck(r.Context(), rm, queueSvc, cr.GetHeadSHA(), cr.GetName(), forge.Check{
+			check := forge.Check{
 				State:       github.CheckRunToState(cr.GetStatus(), cr.GetConclusion()),
 				Description: cr.GetOutput().GetSummary(),
 				TargetURL:   cr.GetDetailsURL(),
-			})
-			// Green CI may make an auto-merge PR enqueuable; the poller decides.
-			if rm.TriggerPoll != nil {
-				rm.TriggerPoll()
 			}
+			routeCheck(r.Context(), rm, queueSvc, cr.GetHeadSHA(), cr.GetName(), check)
+			maybeTriggerPoll(rm, check.State)
 
 		case *gh.StatusEvent:
 			if forge.IsOwnContext(e.GetContext()) {
@@ -80,14 +79,13 @@ func GithubHandler(secret []byte, repos RepoLookup, queueSvc *queue.Service, tri
 			if !ok {
 				break
 			}
-			routeCheck(r.Context(), rm, queueSvc, e.GetSHA(), e.GetContext(), forge.Check{
+			check := forge.Check{
 				State:       forge.ParseCheckState(e.GetState()),
 				Description: e.GetDescription(),
 				TargetURL:   e.GetTargetURL(),
-			})
-			if rm.TriggerPoll != nil {
-				rm.TriggerPoll()
 			}
+			routeCheck(r.Context(), rm, queueSvc, e.GetSHA(), e.GetContext(), check)
+			maybeTriggerPoll(rm, check.State)
 
 		case *gh.InstallationEvent, *gh.InstallationRepositoriesEvent:
 			if triggerDiscovery != nil {
@@ -97,6 +95,14 @@ func GithubHandler(secret []byte, repos RepoLookup, queueSvc *queue.Service, tri
 
 		w.WriteHeader(http.StatusOK)
 	})
+}
+
+// maybeTriggerPoll reconciles only on a green check, the sole transition that
+// can newly enqueue an auto-merge PR. Pending/failure events skip the poll.
+func maybeTriggerPoll(rm *RepoMonitor, state pg.CheckState) {
+	if state == pg.CheckStateSuccess && rm.TriggerPoll != nil {
+		rm.TriggerPoll()
+	}
 }
 
 func lookupGithubRepo(repos RepoLookup, r *gh.Repository) (*RepoMonitor, bool) {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -94,6 +94,10 @@ func Handler(secret string, repos RepoLookup, queueSvc *queue.Service) http.Hand
 			Description: event.Description,
 			TargetURL:   event.TargetURL,
 		})
+		// Green CI may make an auto-merge PR enqueuable; the poller decides.
+		if rm.TriggerPoll != nil {
+			rm.TriggerPoll()
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -89,15 +89,13 @@ func Handler(secret string, repos RepoLookup, queueSvc *queue.Service) http.Hand
 			return
 		}
 
-		routeCheck(r.Context(), rm, queueSvc, event.SHA, event.Context, forge.Check{
+		check := forge.Check{
 			State:       forge.ParseCheckState(event.State),
 			Description: event.Description,
 			TargetURL:   event.TargetURL,
-		})
-		// Green CI may make an auto-merge PR enqueuable; the poller decides.
-		if rm.TriggerPoll != nil {
-			rm.TriggerPoll()
 		}
+		routeCheck(r.Context(), rm, queueSvc, event.SHA, event.Context, check)
+		maybeTriggerPoll(rm, check.State)
 		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/internal/webhook/trigger_internal_test.go
+++ b/internal/webhook/trigger_internal_test.go
@@ -1,0 +1,28 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/store/pg"
+)
+
+// Only a green check can newly enqueue an auto-merge PR, so pending/failure
+// events must not spend a poll (and its API calls).
+func TestMaybeTriggerPoll_OnlyOnSuccess(t *testing.T) {
+	for _, tc := range []struct {
+		state pg.CheckState
+		want  int
+	}{
+		{pg.CheckStateSuccess, 1},
+		{pg.CheckStatePending, 0},
+		{forge.ParseCheckState("failure"), 0},
+	} {
+		var polled int
+		rm := &RepoMonitor{TriggerPoll: func() { polled++ }}
+		maybeTriggerPoll(rm, tc.state)
+		if polled != tc.want {
+			t.Errorf("state %q: polled=%d want %d", tc.state, polled, tc.want)
+		}
+	}
+}

--- a/result-1
+++ b/result-1
@@ -1,0 +1,1 @@
+/nix/store/nixfl55w54gdylfr639nf60ydz17wz80-gitea-mq-0.1.0


### PR DESCRIPTION
Polling `ListOpenPRs` for every managed repo every 30s made API cost scale with
repo count, not queue work. On the GitHub-only eve instance (~40 repos, one App
installation) this exhausted the 6000/hr limit; once throttled the poller
couldn't post the required `gitea-mq` status, leaving auto-merge PRs BLOCKED.

- Idle repos (no active queue entries) skip the periodic poll and reconcile
  only every `GITEA_MQ_IDLE_POLL_INTERVAL` (default 15m) as a downtime
  safety net. Active repos keep the 30s cadence. Green check/status webhooks
  trigger a reconcile so auto-merge PRs still enqueue promptly.
- ETag caching on the GitHub transport: revalidated GETs return 304, which
  GitHub doesn't charge against the rate limit.
- Idle-gating is GitHub-only (`Deps.IdleGating`). Gitea/Forgejo have no
  commit-status webhook, so they must poll every tick.