### PR TITLE
Drop stray result-1 symlink, trim comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /gitea-mq
 /result
+/result-*
 /cmd/gitea-mq/gitea-mq

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -527,12 +527,8 @@ func hasActiveWork(ctx context.Context, deps *Deps) bool {
 	return len(entries) > 0
 }
 
-// Run starts the polling loop. The first poll happens immediately.
-//
-// idleInterval throttles reconciles for repos with no live queue work, but only
-// when deps.IdleGating is set. It must stay off for forges without a
-// commit-status webhook (Gitea, Forgejo): there the poll is the only way to
-// learn a PR went green, so every tick must poll regardless of idle state.
+// Run starts the polling loop. The first poll happens immediately. idleInterval
+// throttles reconciles for idle repos only when deps.IdleGating is set.
 func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) {
 	slog.Info("poller started", "owner", deps.Owner, "repo", deps.Repo, "interval", interval, "idle_interval", idleInterval, "idle_gating", deps.IdleGating)
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -170,9 +170,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		CheckTimeout:        r.deps.CheckTimeout,
 		SkipQueueIfUpToDate: r.deps.SkipQueueIfUpToDate,
 		Batch:               batchEngine,
-		// Only GitHub delivers CI status via webhooks; Gitea/Forgejo must be
-		// polled every tick to learn a PR went green.
-		IdleGating: f.Kind() == forge.KindGithub,
+		IdleGating:          f.Kind() == forge.KindGithub,
 	}
 	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval, r.deps.IdlePollInterval)
 

--- a/result-1
+++ b/result-1
@@ -1,1 +1,0 @@
-/nix/store/nixfl55w54gdylfr639nf60ydz17wz80-gitea-mq-0.1.0


### PR DESCRIPTION
result-1 was a build output symlink accidentally committed. Remove it and widen .gitignore to result-*. Also trim two over-long comments from the idle-gating change.