### PR TITLE
gitea: replace per-operation clones with a persistent git cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ variables.
 | `GITEA_MQ_BISECT_MAX_STEPS` | no | `0` | Cap on CI builds spent bisecting one batch. `0` = unlimited |
 | `GITEA_MQ_REFRESH_INTERVAL` | no | `10s` | Dashboard auto-refresh interval |
 | `GITEA_MQ_DISCOVERY_INTERVAL` | no | `5m` | How often to re-scan Gitea topics and GitHub installations |
+| `GITEA_MQ_CACHE_DIR` | no | `$XDG_CACHE_HOME/gitea-mq` | Directory for persistent bare git clones used for merge operations; unused repos are removed after 30 days |
 | `GITEA_MQ_LOG_LEVEL` | no | `info` | Log level: debug, info, warn, error |
 
 ## Batching (bors-style)

--- a/cmd/gitea-mq/main.go
+++ b/cmd/gitea-mq/main.go
@@ -83,6 +83,8 @@ func run() error {
 	var giteaWebhookSecret string
 	if cfg.Gitea != nil {
 		giteaClient := gitea.NewHTTPClient(cfg.Gitea.URL, cfg.Gitea.Token)
+		giteaClient.SetGitCacheDir(cfg.CacheDir)
+		giteaClient.CleanupGitCache(gitea.DefaultCacheMaxAge)
 		forges.Register(gitea.NewForge(giteaClient, cfg.Gitea.URL))
 		giteaWebhookSecret = cfg.Gitea.WebhookSecret
 		if cfg.Gitea.Topic != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +30,8 @@ type Config struct {
 	RefreshInterval     time.Duration
 	DiscoveryInterval   time.Duration
 	LogLevel            string
+	// CacheDir holds persistent bare git clones used for merge operations.
+	CacheDir string
 }
 
 type GiteaConfig struct {
@@ -149,6 +152,15 @@ func Load() (*Config, error) {
 	cfg.BisectMaxSteps, err = parseInt("GITEA_MQ_BISECT_MAX_STEPS", 0, 0)
 	if err != nil {
 		return nil, err
+	}
+
+	cfg.CacheDir = os.Getenv("GITEA_MQ_CACHE_DIR")
+	if cfg.CacheDir == "" {
+		base, err := os.UserCacheDir()
+		if err != nil {
+			base = os.TempDir()
+		}
+		cfg.CacheDir = filepath.Join(base, "gitea-mq")
 	}
 
 	cfg.LogLevel = envOrDefault("GITEA_MQ_LOG_LEVEL", "info")

--- a/internal/gitea/gitcache.go
+++ b/internal/gitea/gitcache.go
@@ -1,0 +1,196 @@
+package gitea
+
+// Persistent per-repository git cache. One bare, blobless clone per repo,
+// fetched incrementally instead of re-cloned per operation. Merges happen
+// in-memory (merge-tree/commit-tree), so no worktree is ever created.
+//
+// Every git command runs through one runner that injects the API token as an
+// http.<url>.extraHeader -c option, so pushes, fetches and lazy promisor blob
+// fetches are all authenticated and the token never hits disk.
+//
+// The cache is disposable: corrupted clones are deleted and rebuilt, and a
+// .last-used marker drives age-based cleanup of repos removed from config.
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const cacheMarkerFile = ".last-used"
+
+// DefaultCacheMaxAge is how long an unused cached repository is kept.
+const DefaultCacheMaxAge = 30 * 24 * time.Hour
+
+type gitCache struct {
+	baseDir   string
+	authFlags []string            // git -c options prepended to every command
+	redact    func(string) string // strips secrets from git output
+
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newGitCache(baseDir string, authFlags []string, redact func(string) string) *gitCache {
+	return &gitCache{
+		baseDir:   baseDir,
+		authFlags: authFlags,
+		redact:    redact,
+		locks:     make(map[string]*sync.Mutex),
+	}
+}
+
+func (g *gitCache) repoLock(key string) *sync.Mutex {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	l, ok := g.locks[key]
+	if !ok {
+		l = &sync.Mutex{}
+		g.locks[key] = l
+	}
+	return l
+}
+
+// repoPath includes a URL hash so same-named repos on different servers don't collide.
+func (g *gitCache) repoPath(url, owner, repo string) string {
+	sum := sha256.Sum256([]byte(url))
+	return filepath.Join(g.baseDir, owner, fmt.Sprintf("%s-%x.git", repo, sum[:4]))
+}
+
+func (g *gitCache) runner(ctx context.Context, dir string) func(args ...string) (string, error) {
+	return func(args ...string) (string, error) {
+		cmd := exec.CommandContext(ctx, "git", append(append([]string{}, g.authFlags...), args...)...)
+		cmd.Dir = dir
+		cmd.Env = append(
+			os.Environ(),
+			"GIT_TERMINAL_PROMPT=0",
+			"GIT_AUTHOR_NAME=gitea-mq", "GIT_AUTHOR_EMAIL=gitea-mq@localhost",
+			"GIT_COMMITTER_NAME=gitea-mq", "GIT_COMMITTER_EMAIL=gitea-mq@localhost",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return string(out), fmt.Errorf("git %s: %w\n%s",
+				g.redact(strings.Join(args, " ")), err, g.redact(string(out)))
+		}
+		return string(out), nil
+	}
+}
+
+// withRepo fetches refs (branch refspecs or SHAs) into the cached clone and
+// runs fn with a runner bound to it. The per-repo lock is held for the whole
+// operation so gc or a corruption re-clone can't remove objects under fn.
+func (g *gitCache) withRepo(ctx context.Context, url, owner, repo string, refs []string, fn func(run func(args ...string) (string, error)) error) error {
+	l := g.repoLock(owner + "/" + repo)
+	l.Lock()
+	defer l.Unlock()
+
+	path := g.repoPath(url, owner, repo)
+	if err := g.ensure(ctx, path, url, refs); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(path, cacheMarkerFile), nil, 0o644); err != nil {
+		slog.Warn("git cache: write last-used marker", "path", path, "err", err)
+	}
+
+	if err := fn(g.runner(ctx, path)); err != nil {
+		return err
+	}
+	if _, err := g.runner(ctx, path)("gc", "--auto", "--quiet"); err != nil {
+		slog.Debug("git cache: gc --auto failed", "path", path, "err", err)
+	}
+	return nil
+}
+
+// ensure fetches refs, rebuilding the clone if it is corrupted. A healthy
+// clone means the failure was transient (network, auth) and is surfaced.
+func (g *gitCache) ensure(ctx context.Context, path, url string, refs []string) error {
+	err := g.fetch(ctx, path, url, refs)
+	if err == nil || g.healthy(ctx, path) {
+		return err
+	}
+	slog.Warn("git cache corrupted, re-creating", "path", path, "err", err)
+	if rmErr := os.RemoveAll(path); rmErr != nil {
+		return fmt.Errorf("remove corrupted cache %s: %w", path, rmErr)
+	}
+	return g.fetch(ctx, path, url, refs)
+}
+
+func (g *gitCache) fetch(ctx context.Context, path, url string, refs []string) error {
+	run := g.runner(ctx, path)
+	if _, err := os.Stat(filepath.Join(path, "HEAD")); err != nil {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return fmt.Errorf("create cache dir: %w", err)
+		}
+		// Promisor remote lets git backfill blobs lazily whenever a later
+		// command (merge-tree, cat-file, ...) needs file contents.
+		for _, args := range [][]string{
+			{"init", "--bare", "--quiet"},
+			{"remote", "add", "origin", url},
+			{"config", "remote.origin.promisor", "true"},
+			{"config", "remote.origin.partialclonefilter", "blob:none"},
+		} {
+			if _, err := run(args...); err != nil {
+				return fmt.Errorf("init cache: %w", err)
+			}
+		}
+	}
+	// Keep the remote URL current in case the base URL changed.
+	if _, err := run("remote", "set-url", "origin", url); err != nil {
+		return fmt.Errorf("configure cache: %w", err)
+	}
+	args := append([]string{"fetch", "--quiet", "--force", "--prune", "--filter=blob:none", "origin"}, refs...)
+	if _, err := run(args...); err != nil {
+		return fmt.Errorf("fetch into cache: %w", err)
+	}
+	return nil
+}
+
+// healthy is a cheap corruption check used only after a fetch failure.
+func (g *gitCache) healthy(ctx context.Context, path string) bool {
+	if _, err := os.Stat(filepath.Join(path, "HEAD")); err != nil {
+		return false
+	}
+	run := g.runner(ctx, path)
+	out, err := run("for-each-ref", "--count=1", "--format=%(objectname)", "refs/heads")
+	if err != nil {
+		return false
+	}
+	if sha := strings.TrimSpace(out); sha != "" {
+		if _, err := run("cat-file", "-e", sha+"^{commit}"); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// cleanupStale removes cached repos not used within maxAge; this is how
+// caches of repos removed from the configuration go away. Call at startup.
+func (g *gitCache) cleanupStale(maxAge time.Duration) {
+	cutoff := time.Now().Add(-maxAge)
+	dirs, err := filepath.Glob(filepath.Join(g.baseDir, "*", "*.git"))
+	if err != nil {
+		return
+	}
+	for _, dir := range dirs {
+		info, err := os.Stat(filepath.Join(dir, cacheMarkerFile))
+		if err != nil {
+			if info, err = os.Stat(dir); err != nil {
+				continue
+			}
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		slog.Info("git cache: removing stale repository", "path", dir)
+		if err := os.RemoveAll(dir); err != nil {
+			slog.Warn("git cache: remove stale repository", "path", dir, "err", err)
+		}
+	}
+}

--- a/internal/gitea/gitcache_test.go
+++ b/internal/gitea/gitcache_test.go
@@ -1,0 +1,199 @@
+package gitea
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gitIn runs git in dir with a fixed identity and fatals on failure.
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		"GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// newOriginRepo creates a bare "server" repo plus a working clone to commit
+// through, and returns (originPath, workPath).
+func newOriginRepo(t *testing.T) (string, string) {
+	t.Helper()
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	gitIn(t, t.TempDir(), "init", "--bare", "-b", "main", origin)
+	// Local transport needs this for --filter=blob:none fetches.
+	gitIn(t, origin, "config", "uploadpack.allowFilter", "true")
+	work := t.TempDir()
+	gitIn(t, work, "init", "-q", "-b", "main")
+	gitIn(t, work, "remote", "add", "origin", origin)
+	commitFile(t, work, "f", "base\n", "base")
+	gitIn(t, work, "push", "-q", "origin", "main")
+	return origin, work
+}
+
+func commitFile(t *testing.T, work, name, content, msg string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(work, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, work, "add", ".")
+	gitIn(t, work, "commit", "-q", "-m", msg)
+	return gitIn(t, work, "rev-parse", "HEAD")
+}
+
+func newTestCache(t *testing.T) *gitCache {
+	t.Helper()
+	return newGitCache(t.TempDir(), nil, func(s string) string { return s })
+}
+
+// TestGitCache_IncrementalFetch verifies the clone persists across operations
+// and later fetches pick up new commits without re-cloning.
+func TestGitCache_IncrementalFetch(t *testing.T) {
+	origin, work := newOriginRepo(t)
+	g := newTestCache(t)
+	ctx := context.Background()
+	refs := []string{"+refs/heads/main:refs/heads/main"}
+
+	if err := g.withRepo(ctx, origin, "o", "r", refs, func(run gitRunFunc) error {
+		_, err := run("rev-parse", "refs/heads/main")
+		return err
+	}); err != nil {
+		t.Fatalf("first withRepo: %v", err)
+	}
+
+	sha2 := commitFile(t, work, "g", "more\n", "second")
+	gitIn(t, work, "push", "-q", "origin", "main")
+
+	if err := g.withRepo(ctx, origin, "o", "r", refs, func(run gitRunFunc) error {
+		out, err := run("rev-parse", "refs/heads/main")
+		if err != nil {
+			return err
+		}
+		if got := strings.TrimSpace(out); got != sha2 {
+			t.Errorf("main = %s, want %s", got, sha2)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("second withRepo: %v", err)
+	}
+}
+
+// TestGitCache_CorruptionRecreates verifies a corrupted cache is rebuilt
+// instead of failing the operation.
+func TestGitCache_CorruptionRecreates(t *testing.T) {
+	origin, _ := newOriginRepo(t)
+	g := newTestCache(t)
+	ctx := context.Background()
+	refs := []string{"+refs/heads/main:refs/heads/main"}
+
+	if err := g.withRepo(ctx, origin, "o", "r", refs, func(gitRunFunc) error { return nil }); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	// Truncate every object file: refs still resolve but nothing is readable.
+	path := g.repoPath(origin, "o", "r")
+	err := filepath.Walk(filepath.Join(path, "objects"), func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		// Pack files are written read-only.
+		if err := os.Chmod(p, 0o644); err != nil {
+			return err
+		}
+		return os.Truncate(p, 0)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.withRepo(ctx, origin, "o", "r", refs, func(run gitRunFunc) error {
+		_, err := run("cat-file", "-e", "refs/heads/main^{commit}")
+		return err
+	}); err != nil {
+		t.Fatalf("withRepo after corruption: %v", err)
+	}
+}
+
+// TestGitCache_CleanupStale verifies unused cache repos are removed and
+// recently used ones kept.
+func TestGitCache_CleanupStale(t *testing.T) {
+	origin, _ := newOriginRepo(t)
+	g := newTestCache(t)
+	ctx := context.Background()
+	refs := []string{"+refs/heads/main:refs/heads/main"}
+
+	if err := g.withRepo(ctx, origin, "o", "fresh", refs, func(gitRunFunc) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.withRepo(ctx, origin, "o", "stale", refs, func(gitRunFunc) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	stalePath := g.repoPath(origin, "o", "stale")
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(filepath.Join(stalePath, cacheMarkerFile), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	g.cleanupStale(24 * time.Hour)
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("stale cache still present: %v", err)
+	}
+	if _, err := os.Stat(g.repoPath(origin, "o", "fresh")); err != nil {
+		t.Errorf("fresh cache removed: %v", err)
+	}
+}
+
+// TestMergeCommit exercises the in-memory merge: clean merge produces a
+// two-parent commit, conflicting branches report a conflict.
+func TestMergeCommit(t *testing.T) {
+	origin, work := newOriginRepo(t)
+
+	branchHead := func(branch, file, content string) string {
+		gitIn(t, work, "checkout", "-q", "-b", branch, "main")
+		sha := commitFile(t, work, file, content, branch)
+		gitIn(t, work, "push", "-q", "origin", branch)
+		gitIn(t, work, "checkout", "-q", "main")
+		return sha
+	}
+	clean := branchHead("clean", "other", "x\n")
+	conflict := branchHead("conflict", "f", "theirs\n")
+	// Advance main so "conflict" collides on file f.
+	commitFile(t, work, "f", "ours\n", "main edit")
+	gitIn(t, work, "push", "-q", "origin", "main")
+
+	g := newTestCache(t)
+	refs := []string{"+refs/heads/main:refs/heads/main", clean, conflict}
+	err := g.withRepo(context.Background(), origin, "o", "r", refs, func(run gitRunFunc) error {
+		sha, _, err := mergeCommit(run, "refs/heads/main", clean, "merge clean")
+		if err != nil || sha == "" {
+			t.Fatalf("clean merge: sha=%q err=%v", sha, err)
+		}
+		if parents, _ := run("rev-list", "--parents", "-1", sha); len(strings.Fields(parents)) != 3 {
+			t.Errorf("expected 2-parent merge commit, got %q", parents)
+		}
+
+		sha, out, err := mergeCommit(run, "refs/heads/main", conflict, "merge conflict")
+		if err != nil {
+			t.Fatalf("conflict merge errored: %v", err)
+		}
+		if sha != "" || !strings.Contains(out, "f") {
+			t.Errorf("expected conflict on f, got sha=%q out=%q", sha, out)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // HTTPClient implements Client using Gitea's REST API over HTTP.
@@ -19,15 +21,35 @@ type HTTPClient struct {
 	baseURL    string
 	token      string
 	httpClient *http.Client
+	gitCache   *gitCache
 }
 
 // NewHTTPClient creates a new HTTP-based Gitea API client.
 func NewHTTPClient(baseURL, token string) *HTTPClient {
-	return &HTTPClient{
+	c := &HTTPClient{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		token:      token,
 		httpClient: &http.Client{},
 	}
+	// Git auth via extraHeader; see gitcache.go for why.
+	var authFlags []string
+	if token != "" {
+		authFlags = []string{"-c", "http." + c.baseURL + "/.extraheader=Authorization: token " + token}
+	}
+	c.gitCache = newGitCache(filepath.Join(os.TempDir(), "gitea-mq-cache"), authFlags, c.redact)
+	return c
+}
+
+// SetGitCacheDir points the persistent git cache at dir. Call before any
+// merge/push operation; the default is a directory under os.TempDir().
+func (c *HTTPClient) SetGitCacheDir(dir string) {
+	c.gitCache.baseDir = dir
+}
+
+// CleanupGitCache removes cached repositories not used within maxAge, e.g.
+// repositories removed from the configuration. Call at startup.
+func (c *HTTPClient) CleanupGitCache(maxAge time.Duration) {
+	c.gitCache.cleanupStale(maxAge)
 }
 
 // do executes an HTTP request with authentication and returns the response.
@@ -389,75 +411,65 @@ func (c *HTTPClient) redact(s string) string {
 	return strings.ReplaceAll(s, c.token, "***")
 }
 
-// MergeBranches creates a merge of head into base and pushes it as branch
-// gitea-mq/<head-short>. It shells out to git because Gitea has no API to merge
-// two arbitrary refs into a new branch.
-//
-// Steps:
-//  1. Shallow-clone the repo (base branch only)
-//  2. Fetch the head SHA
-//  3. git merge --no-ff the head SHA into base
-//  4. Push the result as gitea-mq/<head-short>
-//
-// On conflict git merge exits non-zero and we return a MergeConflictError.
+// MergeBranches creates a merge commit of head into base and pushes it as
+// branchName, entirely inside the persistent git cache (Gitea has no API to
+// merge two arbitrary refs into a new branch). Conflicts are returned as
+// MergeConflictError.
 func (c *HTTPClient) MergeBranches(ctx context.Context, owner, repo, base, head, branchName string) (*MergeResult, error) {
-	gitRun, cleanup, err := gitTempRepo(ctx, "gitea-mq-merge-*",
-		"GIT_AUTHOR_NAME=gitea-mq", "GIT_AUTHOR_EMAIL=gitea-mq@localhost",
-		"GIT_COMMITTER_NAME=gitea-mq", "GIT_COMMITTER_EMAIL=gitea-mq@localhost")
+	refs := []string{"+refs/heads/" + base + ":refs/heads/" + base, head}
+	var result *MergeResult
+	err := c.gitCache.withRepo(ctx, c.cloneURL(owner, repo), owner, repo, refs, func(run gitRunFunc) error {
+		sha, conflictOut, err := mergeCommit(run, "refs/heads/"+base, head, "mq: merge "+head+" into "+base)
+		if err != nil {
+			return fmt.Errorf("merge: %w", err)
+		}
+		if sha == "" {
+			return &MergeConflictError{Base: base, Head: head, Message: conflictOut}
+		}
+		if _, err := run("push", "--quiet", "origin", sha+":refs/heads/"+branchName); err != nil {
+			return fmt.Errorf("push: %w", err)
+		}
+		result = &MergeResult{SHA: sha}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
+	slog.Debug("created merge branch", "branch", branchName, "sha", shortSHA(result.SHA))
+	return result, nil
+}
 
-	// Wrap the runner so failures carry the redacted command line and output.
-	run := func(args ...string) ([]byte, error) {
-		out, err := gitRun(args...)
-		if err != nil {
-			return out, fmt.Errorf("git %s: %w\n%s", c.redact(strings.Join(args, " ")), err, c.redact(string(out)))
-		}
-		return out, nil
-	}
+// gitRunFunc executes one git command inside the cached repository.
+type gitRunFunc = func(args ...string) (string, error)
 
-	authedURL := c.authedCloneURL(owner, repo)
-
-	// Full clone of the base branch. We need enough history for git to
-	// find the common ancestor with the PR head, so shallow clones don't
-	// work reliably here.
-	if _, err := run("clone", "--single-branch", "--branch", base, authedURL, "."); err != nil {
-		return nil, fmt.Errorf("clone: %w", err)
-	}
-
-	// Fetch the PR head SHA so we can merge it.
-	if _, err := run("fetch", "origin", head); err != nil {
-		return nil, fmt.Errorf("fetch head: %w", err)
-	}
-
-	// Merge head into base. --no-ff ensures a merge commit even if fast-forward
-	// is possible, so CI always sees the combined result.
-	mergeOut, mergeErr := run("merge", "--no-ff", "-m", "mq: merge "+head+" into "+base, "FETCH_HEAD")
-	if mergeErr != nil {
-		// Check if this is a merge conflict.
-		if strings.Contains(string(mergeOut), "CONFLICT") || strings.Contains(string(mergeOut), "Automatic merge failed") {
-			return nil, &MergeConflictError{Base: base, Head: head, Message: string(mergeOut)}
-		}
-		return nil, fmt.Errorf("merge: %w", mergeErr)
-	}
-
-	// Push as the requested branch name.
-	if _, err := run("push", "origin", "HEAD:refs/heads/"+branchName); err != nil {
-		return nil, fmt.Errorf("push: %w", err)
-	}
-
-	// Read the merge commit SHA.
-	shaOut, err := run("rev-parse", "HEAD")
+// mergeCommit merges head into base in-memory (merge-tree + commit-tree) and
+// returns the merge commit SHA; a conflict returns an empty SHA plus
+// merge-tree's report. A merge commit is created even when fast-forward would
+// be possible, so CI always sees the combined result (like merge --no-ff).
+func mergeCommit(run gitRunFunc, base, head, msg string) (sha, conflictOut string, err error) {
+	out, err := run("merge-tree", "--write-tree", base, head)
 	if err != nil {
-		return nil, fmt.Errorf("rev-parse: %w", err)
+		// merge-tree exits 1 on content conflicts and >1 on real errors.
+		if gitExitCode(err) == 1 {
+			return "", out, nil
+		}
+		return "", "", err
 	}
-	sha := strings.TrimSpace(string(shaOut))
+	tree := strings.TrimSpace(out)
+	commit, err := run("commit-tree", tree, "-p", base, "-p", head, "-m", msg)
+	if err != nil {
+		return "", "", err
+	}
+	return strings.TrimSpace(commit), "", nil
+}
 
-	slog.Debug("created merge branch", "branch", branchName, "sha", shortSHA(sha))
-
-	return &MergeResult{SHA: sha}, nil
+// gitExitCode extracts the git process exit code from a runner error, or -1.
+func gitExitCode(err error) int {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
 }
 
 // StackStep is the per-head outcome of StackMerges.
@@ -466,119 +478,81 @@ type StackStep struct {
 	Err      error
 }
 
-// StackMerges clones base once and merges each head onto it in order, pushing
-// the result as branch. On a per-head conflict the merge is aborted and the
-// step marked; subsequent heads merge onto the pre-conflict tip. A clone or
-// final-push failure is returned as err so the caller can retry the whole
-// build instead of mis-attributing a transient network error to one PR.
+// StackMerges merges each head onto base in order inside the cached repo and
+// pushes the result as branch. On a per-head conflict or fetch failure the
+// step is marked and subsequent heads merge onto the pre-failure tip. A
+// cache or final-push failure is returned as err so the caller can retry the
+// whole build instead of mis-attributing a transient error to one PR.
 func (c *HTTPClient) StackMerges(ctx context.Context, owner, repo, base string, heads []string, branch string) (string, []StackStep, error) {
-	run, cleanup, err := gitTempRepo(ctx, "gitea-mq-stack-*",
-		"GIT_AUTHOR_NAME=gitea-mq", "GIT_AUTHOR_EMAIL=gitea-mq@localhost",
-		"GIT_COMMITTER_NAME=gitea-mq", "GIT_COMMITTER_EMAIL=gitea-mq@localhost")
+	steps := make([]StackStep, len(heads))
+	refs := []string{"+refs/heads/" + base + ":refs/heads/" + base}
+	var tip string
+	err := c.gitCache.withRepo(ctx, c.cloneURL(owner, repo), owner, repo, refs, func(run gitRunFunc) error {
+		current := "refs/heads/" + base
+		for i, head := range heads {
+			// Heads are fetched one by one so a vanished head SHA fails only
+			// its own step, not the whole batch.
+			if _, err := run("fetch", "--quiet", "--filter=blob:none", "origin", head); err != nil {
+				steps[i].Err = fmt.Errorf("fetch %s: %w", shortSHA(head), err)
+				continue
+			}
+			sha, _, err := mergeCommit(run, current, head,
+				fmt.Sprintf("mq: merge %s into %s", shortSHA(head), base))
+			if err != nil {
+				steps[i].Err = fmt.Errorf("merge %s: %w", shortSHA(head), err)
+				continue
+			}
+			if sha == "" {
+				steps[i].Conflict = true
+				continue
+			}
+			current, tip = sha, sha
+		}
+		if tip == "" {
+			return nil
+		}
+		if _, err := run("push", "--quiet", "origin", tip+":refs/heads/"+branch); err != nil {
+			return fmt.Errorf("push %s: %w", branch, err)
+		}
+		return nil
+	})
 	if err != nil {
 		return "", nil, err
 	}
-	defer cleanup()
-
-	url := c.authedCloneURL(owner, repo)
-
-	if out, err := run("clone", "--single-branch", "--branch", base, url, "."); err != nil {
-		return "", nil, fmt.Errorf("clone %s: %w\n%s", base, err, c.redact(string(out)))
+	if tip != "" {
+		slog.Debug("stack-merge built", "branch", branch, "heads", len(heads), "tip", shortSHA(tip))
 	}
-
-	steps := make([]StackStep, len(heads))
-	var tip string
-	for i, head := range heads {
-		if out, err := run("fetch", "-q", "origin", head); err != nil {
-			steps[i].Err = fmt.Errorf("fetch %s: %s", shortSHA(head), c.redact(string(out)))
-			continue
-		}
-		out, err := run("merge", "--no-ff", "-m",
-			fmt.Sprintf("mq: merge %s into %s", shortSHA(head), base), "FETCH_HEAD")
-		if err != nil {
-			s := string(out)
-			if strings.Contains(s, "CONFLICT") || strings.Contains(s, "Automatic merge failed") {
-				steps[i].Conflict = true
-			} else {
-				steps[i].Err = fmt.Errorf("merge %s: %s", shortSHA(head), c.redact(string(out)))
-			}
-			_, _ = run("merge", "--abort")
-			continue
-		}
-		sha, _ := run("rev-parse", "HEAD")
-		tip = strings.TrimSpace(string(sha))
-	}
-
-	if tip == "" {
-		return "", steps, nil
-	}
-	if out, err := run("push", "origin", "HEAD:refs/heads/"+branch); err != nil {
-		return "", nil, fmt.Errorf("push %s: %w\n%s", branch, err, c.redact(string(out)))
-	}
-	slog.Debug("stack-merge built", "branch", branch, "heads", len(heads), "tip", shortSHA(tip))
 	return tip, steps, nil
 }
 
-// authedCloneURL returns the repo's HTTPS clone URL with the API token
-// embedded as basic-auth for non-interactive git operations.
-func (c *HTTPClient) authedCloneURL(owner, repo string) string {
-	plain := fmt.Sprintf("%s/%s/%s.git", c.baseURL, owner, repo)
-	scheme, rest, _ := strings.Cut(plain, "://")
-	return fmt.Sprintf("%s://gitea-mq:%s@%s", scheme, c.token, rest)
+// cloneURL returns the repo's plain HTTPS clone URL; authentication is
+// injected per git invocation via an extraHeader, never stored in the URL.
+func (c *HTTPClient) cloneURL(owner, repo string) string {
+	return fmt.Sprintf("%s/%s/%s.git", c.baseURL, owner, repo)
 }
 
-// gitTempRepo creates a temporary directory and returns a runner that
-// executes git commands inside it with prompts disabled plus the given extra
-// environment variables. cleanup removes the directory.
-func gitTempRepo(ctx context.Context, pattern string, extraEnv ...string) (func(args ...string) ([]byte, error), func(), error) {
-	tmpDir, err := os.MkdirTemp("", pattern)
-	if err != nil {
-		return nil, nil, fmt.Errorf("create temp dir: %w", err)
-	}
-	run := func(args ...string) ([]byte, error) {
-		cmd := exec.CommandContext(ctx, "git", args...)
-		cmd.Dir = tmpDir
-		cmd.Env = append(append(os.Environ(), "GIT_TERMINAL_PROMPT=0"), extraEnv...)
-		return cmd.CombinedOutput()
-	}
-	return run, func() { _ = os.RemoveAll(tmpDir) }, nil
-}
-
-// FastForwardRef pushes sha to refs/heads/branch with a non-force refspec.
-// git's client-side fast-forward check needs sha's ancestry back to the
-// current branch tip, so we fetch sha without a depth limit. The server
-// already has every object (sha is the tip of a branch we built there) so the
-// resulting push pack is empty — cost is the fetch, same order as the full
-// single-branch clone MergeBranches already does.
+// FastForwardRef pushes sha to refs/heads/branch with a non-force refspec
+// straight from the cached repo. git's client-side fast-forward check needs
+// sha's ancestry back to the current branch tip, so both are fetched first;
+// the push pack itself is empty because the server already has sha.
 func (c *HTTPClient) FastForwardRef(ctx context.Context, owner, repo, branch, sha string) error {
-	run, cleanup, err := gitTempRepo(ctx, "gitea-mq-ff-*")
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	url := c.authedCloneURL(owner, repo)
-
-	if out, err := run("init", "--bare", "-q"); err != nil {
-		return fmt.Errorf("git init: %s: %w", out, err)
-	}
-	if out, err := run("fetch", "-q", url, sha); err != nil {
-		return fmt.Errorf("git fetch %s: %s: %w", shortSHA(sha), c.redact(string(out)), err)
-	}
-	out, err := run("push", url, sha+":refs/heads/"+branch)
-	if err == nil {
-		return nil
-	}
-	msg := c.redact(string(out))
-	low := strings.ToLower(msg)
-	switch {
-	case strings.Contains(low, "non-fast-forward") || strings.Contains(low, "fetch first"):
-		return &NotFastForwardError{Branch: branch, SHA: sha}
-	case strings.Contains(low, "protected branch") || strings.Contains(low, "not allowed to push"):
-		return &ProtectedBranchError{Branch: branch, Message: msg}
-	default:
-		return fmt.Errorf("git push %s: %w\n%s", branch, err, msg)
-	}
+	refs := []string{"+refs/heads/" + branch + ":refs/heads/" + branch, sha}
+	return c.gitCache.withRepo(ctx, c.cloneURL(owner, repo), owner, repo, refs, func(run gitRunFunc) error {
+		out, err := run("push", "origin", sha+":refs/heads/"+branch)
+		if err == nil {
+			return nil
+		}
+		msg := c.redact(out)
+		low := strings.ToLower(msg)
+		switch {
+		case strings.Contains(low, "non-fast-forward") || strings.Contains(low, "fetch first"):
+			return &NotFastForwardError{Branch: branch, SHA: sha}
+		case strings.Contains(low, "protected branch") || strings.Contains(low, "not allowed to push"):
+			return &ProtectedBranchError{Branch: branch, Message: msg}
+		default:
+			return fmt.Errorf("git push %s: %w", branch, err)
+		}
+	})
 }
 
 // EditIssueState sets an issue/PR state via PATCH /repos/{o}/{r}/issues/{n}.

--- a/internal/integration/gitea_cache_test.go
+++ b/internal/integration/gitea_cache_test.go
@@ -1,0 +1,84 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mic92/gitea-mq/internal/gitea"
+	"github.com/Mic92/gitea-mq/internal/testutil"
+)
+
+// TestMergeBranches_PrivateRepo_CachedClone is the regression test for the
+// blobless-cache credential trap: with a private repo, every git operation —
+// including lazy promisor blob fetches during merge-tree and the push — must
+// be authenticated. It runs MergeBranches twice against the same persistent
+// cache so the second run exercises the incremental-fetch path.
+func TestMergeBranches_PrivateRepo_CachedClone(t *testing.T) {
+	gs := testutil.GiteaInstance()
+	if gs == nil {
+		t.Skip("gitea server not available")
+	}
+	api := testutil.NewGiteaAPI(gs.URL)
+	api.CreateToken(t)
+	c := gitea.NewHTTPClient(gs.URL, api.Token)
+	c.SetGitCacheDir(t.TempDir())
+	ctx := t.Context()
+
+	repo := "cache-private-test"
+	api.MustDo(t, "POST", "/user/repos", `{"name": "`+repo+`", "auto_init": false, "default_branch": "main", "private": true}`)
+	if err := gs.PatchRepoHooks("testuser", repo); err != nil {
+		t.Fatalf("patch hooks: %v", err)
+	}
+
+	tmp := t.TempDir()
+	url := fmt.Sprintf("http://gitea-mq:%s@%s/testuser/%s.git", api.Token, gs.URL[len("http://"):], repo)
+	run := func(args ...string) string {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tmp
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_TERMINAL_PROMPT=0")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+	write := func(name, body string) { _ = os.WriteFile(filepath.Join(tmp, name), []byte(body), 0o644) }
+
+	run("init", "-q", "-b", "main")
+	write("f", "base\n")
+	run("add", ".")
+	run("commit", "-q", "-m", "base")
+	run("push", "-q", url, "main")
+
+	head := func(branch, file, body string) string {
+		run("checkout", "-q", "-b", branch, "main")
+		write(file, body)
+		run("add", ".")
+		run("commit", "-q", "-m", branch)
+		run("push", "-q", url, branch)
+		run("checkout", "-q", "main")
+		return run("rev-parse", branch)[:40]
+	}
+	h1 := head("p1", "a", "a\n")
+
+	res, err := c.MergeBranches(ctx, "testuser", repo, "main", h1, "gitea-mq/one")
+	if err != nil {
+		t.Fatalf("first MergeBranches: %v", err)
+	}
+	if res.SHA == "" {
+		t.Fatal("empty merge SHA")
+	}
+
+	// Second merge reuses the cached clone: incremental fetch plus lazy blob
+	// fetch of a file the first merge never touched.
+	h2 := head("p2", "f", "changed\n")
+	if _, err := c.MergeBranches(ctx, "testuser", repo, "main", h2, "gitea-mq/two"); err != nil {
+		t.Fatalf("second MergeBranches: %v", err)
+	}
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -252,6 +252,9 @@ in
         Restart = "on-failure";
         RestartSec = 5;
 
+        # Persistent bare git clones used for merge operations.
+        CacheDirectory = "gitea-mq";
+
         # Credentials: systemd loads files and exposes them under /run/credentials.
         LoadCredential =
           lib.optionals giteaEnabled [
@@ -277,6 +280,7 @@ in
         GITEA_MQ_REFRESH_INTERVAL = cfg.refreshInterval;
         GITEA_MQ_DISCOVERY_INTERVAL = cfg.discoveryInterval;
         GITEA_MQ_LOG_LEVEL = cfg.logLevel;
+        GITEA_MQ_CACHE_DIR = "/var/cache/gitea-mq";
       }
       // lib.optionalAttrs (cfg.repos != [ ]) {
         GITEA_MQ_REPOS = lib.concatStringsSep "," cfg.repos;

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -143,12 +143,13 @@ pkgs.testers.runNixOSTest {
     token = json.loads(token_json)["sha1"]
 
     # Create a repo and branch protection before starting gitea-mq,
-    # so auto-setup finds them on first run.
+    # so auto-setup finds them on first run. The repo is private so the merge
+    # queue's git operations (fetch, lazy blob fetch, push) must authenticate.
     machine.succeed(
         f"curl -sf -X POST http://localhost:3000/api/v1/user/repos "
         f"-H 'Authorization: token {token}' "
         f"-H 'Content-Type: application/json' "
-        f"-d '{{\"name\": \"testrepo\", \"auto_init\": true, \"default_branch\": \"main\"}}'"
+        f"-d '{{\"name\": \"testrepo\", \"auto_init\": true, \"default_branch\": \"main\", \"private\": true}}'"
     )
 
     # Create a file with many lines up front (before branch protection blocks


### PR DESCRIPTION

MergeBranches, StackMerges and FastForwardRef paid a full single-branch
clone per queue advance, which gets expensive on large repositories, and
detected merge conflicts by grepping git output for CONFLICT strings,
which is fragile across git versions and locales.

Keep one bare, blobless (--filter=blob:none) clone per repository under
GITEA_MQ_CACHE_DIR and fetch incrementally instead. Merge commits are
built in-memory with git merge-tree --write-tree + commit-tree, so no
worktree or temporary clone is created and conflicts are detected by
exit status. Every git command runs through a single runner that injects
the API token as an http.<url>.extraHeader option, so lazy promisor blob
fetches and pushes in private repositories are always authenticated
while the token never lands in git config on disk.

The cache is disposable: corrupted clones are deleted and rebuilt, gc
--auto runs opportunistically, and repositories unused for 30 days (e.g.
removed from the configuration) are swept at startup.

The NixOS module provisions /var/cache/gitea-mq via CacheDirectory, and
the NixOS test now uses a private repository so the authenticated git
path is exercised end to end.
