### PR TITLE
poller: make timeout and Run tests deterministic

### DIFF
--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/logutil"
 	"github.com/Mic92/gitea-mq/internal/merge"
 	"github.com/Mic92/gitea-mq/internal/queue"
 	"github.com/Mic92/gitea-mq/internal/store/pg"
@@ -208,14 +209,14 @@ func (e *Engine) Build(ctx context.Context, b *pg.Batch) error {
 	// raced in before SetMergeBranch (still keyed on the old SHA) is wiped.
 	desc := fmt.Sprintf("Testing batch #%d (%d PRs)", b.ID, len(b.MemberIds))
 	for _, ent := range surv {
-		_ = e.Queue.SetMergeBranch(ctx, e.RepoID, ent.PrNumber, branch, tip)
+		logutil.WarnIfErr(e.Queue.SetMergeBranch(ctx, e.RepoID, ent.PrNumber, branch, tip), "set merge branch failed", "pr", ent.PrNumber)
 		if first {
-			_ = e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
+			logutil.WarnIfErr(e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
 				State: pg.CheckStatePending, Description: desc, TargetURL: e.prURL(ent.PrNumber),
-			})
+			}), "set mq status failed", "pr", ent.PrNumber)
 		}
 	}
-	_ = e.Queue.ClearCheckStatuses(ctx, b.CurrentIds)
+	logutil.WarnIfErr(e.Queue.ClearCheckStatuses(ctx, b.CurrentIds), "clear check statuses failed", "batch", b.ID)
 
 	slog.Info("batch built", "batch", b.ID, "build", b.Builds, "sha", tip,
 		"current", len(surv), "pending", len(loadPending(b.Pending)))
@@ -261,9 +262,9 @@ func (e *Engine) HandlePass(ctx context.Context, b *pg.Batch) error {
 	var wg sync.WaitGroup
 	for i := range entries {
 		ent := &entries[i]
-		_ = e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
+		logutil.WarnIfErr(e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
 			State: pg.CheckStateSuccess, Description: desc, TargetURL: e.prURL(ent.PrNumber),
-		})
+		}), "set mq status failed", "pr", ent.PrNumber)
 		if _, err := e.Queue.Dequeue(ctx, e.RepoID, ent.PrNumber); err != nil {
 			slog.Warn("dequeue landed PR failed", "pr", ent.PrNumber, "err", err)
 		}
@@ -319,7 +320,7 @@ func (e *Engine) HandleFail(ctx context.Context, b *pg.Batch, failedCheck, targe
 	b.CurrentIds = left
 	// Right-half members leave the branch; clear their routing so late events
 	// for this build's SHA cannot reach them.
-	_ = e.Queue.ClearMergeBranch(ctx, right)
+	logutil.WarnIfErr(e.Queue.ClearMergeBranch(ctx, right), "clear merge branch failed", "batch", b.ID)
 	slog.Info("batch bisecting", "batch", b.ID, "build", b.Builds,
 		"failed_check", failedCheck, "left", len(left), "right", len(right))
 	return e.rebuild(ctx, b)
@@ -407,8 +408,8 @@ func (e *Engine) ReconcileLive(ctx context.Context) error {
 		case pg.BatchStateTesting:
 			entries, _ := e.Queue.GetEntriesByIDs(ctx, b.CurrentIds)
 			for _, ent := range entries {
-				_ = e.Queue.SetMergeBranch(ctx, e.RepoID, ent.PrNumber,
-					b.BranchName.String, b.BranchSha.String)
+				logutil.WarnIfErr(e.Queue.SetMergeBranch(ctx, e.RepoID, ent.PrNumber,
+					b.BranchName.String, b.BranchSha.String), "set merge branch failed", "pr", ent.PrNumber)
 			}
 		}
 		unlock()
@@ -472,7 +473,7 @@ func (e *Engine) next(ctx context.Context, b *pg.Batch) error {
 	if err := e.Queue.SaveBatch(ctx, b); err != nil {
 		return err
 	}
-	_ = e.Forge.DeleteBranch(ctx, e.Owner, e.Repo, b.BranchName.String)
+	logutil.WarnIfErr(e.Forge.DeleteBranch(ctx, e.Owner, e.Repo, b.BranchName.String), "delete batch branch failed", "branch", b.BranchName.String)
 
 	slog.Info("batch done", "batch", b.ID, "landed", len(b.LandedIds),
 		"ejected", len(b.EjectedIds), "builds", b.Builds, "flaky", b.Flaky)
@@ -484,11 +485,11 @@ func (e *Engine) next(ctx context.Context, b *pg.Batch) error {
 
 // eject removes a single member: status, cancel automerge, comment, dequeue.
 func (e *Engine) eject(ctx context.Context, b *pg.Batch, ent *pg.QueueEntry, state pg.CheckState, statusDesc, comment string) {
-	_ = e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
+	logutil.WarnIfErr(e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
 		State: state, Description: statusDesc, TargetURL: e.prURL(ent.PrNumber),
-	})
-	_ = e.Forge.CancelAutoMerge(ctx, e.Owner, e.Repo, ent.PrNumber)
-	_ = e.Forge.Comment(ctx, e.Owner, e.Repo, ent.PrNumber, comment)
+	}), "set mq status failed", "pr", ent.PrNumber)
+	logutil.WarnIfErr(e.Forge.CancelAutoMerge(ctx, e.Owner, e.Repo, ent.PrNumber), "cancel automerge failed", "pr", ent.PrNumber)
+	logutil.WarnIfErr(e.Forge.Comment(ctx, e.Owner, e.Repo, ent.PrNumber, comment), "post comment failed", "pr", ent.PrNumber)
 	if _, err := e.Queue.Dequeue(ctx, e.RepoID, ent.PrNumber); err != nil {
 		slog.Warn("dequeue ejected PR failed", "pr", ent.PrNumber, "err", err)
 	}
@@ -520,9 +521,9 @@ func (e *Engine) ensureMergedOrClose(ctx context.Context, ent *pg.QueueEntry, sh
 		case <-time.After(interval):
 		}
 	}
-	_ = e.Forge.Comment(ctx, e.Owner, e.Repo, ent.PrNumber,
-		fmt.Sprintf("✅ Merged as `%s` via batch #%d.", sha, batchID))
-	_ = e.Forge.ClosePR(ctx, e.Owner, e.Repo, ent.PrNumber)
+	logutil.WarnIfErr(e.Forge.Comment(ctx, e.Owner, e.Repo, ent.PrNumber,
+		fmt.Sprintf("✅ Merged as `%s` via batch #%d.", sha, batchID)), "post comment failed", "pr", ent.PrNumber)
+	logutil.WarnIfErr(e.Forge.ClosePR(ctx, e.Owner, e.Repo, ent.PrNumber), "close pr failed", "pr", ent.PrNumber)
 }
 
 func (e *Engine) prURL(n int64) string {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -170,9 +170,18 @@ type SetupConfig struct {
 	WebhookSecret string
 }
 
+// Capabilities lets callers branch on forge features instead of on Kind.
+type Capabilities struct {
+	// StatusWebhook: forge delivers commit-status/check-run results via
+	// webhooks. Without it CI results must be polled, so idle gating is
+	// unsafe.
+	StatusWebhook bool
+}
+
 // Forge abstracts all operations gitea-mq performs against a hosting forge.
 type Forge interface {
 	Kind() Kind
+	Capabilities() Capabilities
 	RepoHTMLURL(owner, name string) string
 	BranchHTMLURL(owner, name, branch string) string
 

--- a/internal/forge/mock.go
+++ b/internal/forge/mock.go
@@ -19,6 +19,7 @@ type MockForge struct {
 	Calls []MockCall
 
 	KindVal Kind
+	CapabilitiesVal Capabilities
 
 	RepoHTMLURLFn       func(owner, name string) string
 	BranchHTMLURLFn     func(owner, name, branch string) string
@@ -63,6 +64,10 @@ func (m *MockForge) CallsTo(method string) []MockCall {
 
 func (m *MockForge) Kind() Kind {
 	return cmp.Or(m.KindVal, KindGitea)
+}
+
+func (m *MockForge) Capabilities() Capabilities {
+	return m.CapabilitiesVal
 }
 
 func (m *MockForge) RepoHTMLURL(owner, name string) string {

--- a/internal/forge/mock.go
+++ b/internal/forge/mock.go
@@ -18,7 +18,7 @@ type MockForge struct {
 	mu    sync.Mutex
 	Calls []MockCall
 
-	KindVal Kind
+	KindVal         Kind
 	CapabilitiesVal Capabilities
 
 	RepoHTMLURLFn       func(owner, name string) string

--- a/internal/gitea/forge.go
+++ b/internal/gitea/forge.go
@@ -46,6 +46,11 @@ func (f *giteaForge) StackMerges(ctx context.Context, owner, repo, base string, 
 
 func (f *giteaForge) Kind() forge.Kind { return forge.KindGitea }
 
+// Gitea/Forgejo have no commit-status webhook; CI results are polled.
+func (f *giteaForge) Capabilities() forge.Capabilities {
+	return forge.Capabilities{StatusWebhook: false}
+}
+
 func (f *giteaForge) RepoHTMLURL(owner, name string) string {
 	return f.baseURL + "/" + owner + "/" + name
 }

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -538,21 +538,40 @@ func (c *HTTPClient) cloneURL(owner, repo string) string {
 func (c *HTTPClient) FastForwardRef(ctx context.Context, owner, repo, branch, sha string) error {
 	refs := []string{"+refs/heads/" + branch + ":refs/heads/" + branch, sha}
 	return c.gitCache.withRepo(ctx, c.cloneURL(owner, repo), owner, repo, refs, func(run gitRunFunc) error {
-		out, err := run("push", "origin", sha+":refs/heads/"+branch)
+		out, err := run("push", "--porcelain", "origin", sha+":refs/heads/"+branch)
 		if err == nil {
 			return nil
 		}
-		msg := c.redact(out)
-		low := strings.ToLower(msg)
-		switch {
-		case strings.Contains(low, "non-fast-forward") || strings.Contains(low, "fetch first"):
-			return &NotFastForwardError{Branch: branch, SHA: sha}
-		case strings.Contains(low, "protected branch") || strings.Contains(low, "not allowed to push"):
-			return &ProtectedBranchError{Branch: branch, Message: msg}
-		default:
-			return fmt.Errorf("git push %s: %w", branch, err)
-		}
+		return classifyPushFailure(branch, sha, c.redact(out), err)
 	})
+}
+
+// classifyPushFailure maps a failed `git push --porcelain` to a typed error
+// by parsing its rejection line: "! <from>:<to> <summary> (<reason>)".
+// Client-side ancestry rejections carry fixed reasons; "[remote rejected]"
+// carries the server hook's message, i.e. branch protection denied the push.
+// Output without a rejection line stays a generic error.
+func classifyPushFailure(branch, sha, out string, err error) error {
+	for line := range strings.Lines(out) {
+		flag, rest, ok := strings.Cut(line, "\t")
+		if !ok || flag != "!" {
+			continue
+		}
+		_, result, ok := strings.Cut(rest, "\t")
+		if !ok {
+			continue
+		}
+		summary, reason, _ := strings.Cut(strings.TrimSpace(result), " (")
+		reason = strings.TrimSuffix(reason, ")")
+		if summary == "[remote rejected]" {
+			return &ProtectedBranchError{Branch: branch, Message: reason}
+		}
+		switch reason {
+		case "non-fast-forward", "fetch first", "needs force", "stale info":
+			return &NotFastForwardError{Branch: branch, SHA: sha}
+		}
+	}
+	return fmt.Errorf("git push %s: %w", branch, err)
 }
 
 // EditIssueState sets an issue/PR state via PATCH /repos/{o}/{r}/issues/{n}.

--- a/internal/gitea/push_test.go
+++ b/internal/gitea/push_test.go
@@ -1,0 +1,68 @@
+package gitea
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyPushFailure(t *testing.T) {
+	genericErr := errors.New("exit status 1")
+
+	cases := []struct {
+		name string
+		out  string
+		want any // *NotFastForwardError, *ProtectedBranchError, or nil for generic
+	}{
+		{
+			name: "non-fast-forward",
+			out: "To https://gitea.example.com/o/r.git\n" +
+				"!\trefs/heads/main:refs/heads/main\t[rejected] (non-fast-forward)\n" +
+				"Done\n",
+			want: &NotFastForwardError{},
+		},
+		{
+			name: "fetch first",
+			out: "To https://gitea.example.com/o/r.git\n" +
+				"!\tabc123:refs/heads/main\t[rejected] (fetch first)\n" +
+				"Done\n",
+			want: &NotFastForwardError{},
+		},
+		{
+			name: "remote rejected by branch protection",
+			out: "To https://gitea.example.com/o/r.git\n" +
+				"!\tabc123:refs/heads/main\t[remote rejected] (Not allowed to push to protected branch main.)\n" +
+				"Done\n",
+			want: &ProtectedBranchError{},
+		},
+		{
+			name: "no status line",
+			out:  "fatal: unable to access repo: connection refused\n",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := classifyPushFailure("main", "abc123", tc.out, genericErr)
+			switch tc.want.(type) {
+			case *NotFastForwardError:
+				var e *NotFastForwardError
+				if !errors.As(err, &e) {
+					t.Fatalf("got %v, want NotFastForwardError", err)
+				}
+			case *ProtectedBranchError:
+				var e *ProtectedBranchError
+				if !errors.As(err, &e) {
+					t.Fatalf("got %v, want ProtectedBranchError", err)
+				}
+				if e.Message == "" {
+					t.Fatal("expected server message in ProtectedBranchError")
+				}
+			default:
+				if !errors.Is(err, genericErr) {
+					t.Fatalf("got %v, want wrapped generic error", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/github/forge.go
+++ b/internal/github/forge.go
@@ -31,6 +31,10 @@ func NewForge(app *App, htmlURL string) forge.Forge {
 
 func (f *githubForge) Kind() forge.Kind { return forge.KindGithub }
 
+func (f *githubForge) Capabilities() forge.Capabilities {
+	return forge.Capabilities{StatusWebhook: true}
+}
+
 func (f *githubForge) RepoHTMLURL(owner, name string) string {
 	return fmt.Sprintf("%s/%s/%s", f.htmlURL, owner, name)
 }

--- a/internal/github/forge_test.go
+++ b/internal/github/forge_test.go
@@ -169,6 +169,7 @@ func TestForge_FastForward(t *testing.T) {
 	srv, f := newTestForge(t)
 	repo := srv.Repo("org", "app")
 	repo.Refs["main"] = "base"
+	repo.Parents["merge(base,sha)"] = []string{"base", "sha"}
 	ctx := context.Background()
 
 	if err := f.FastForward(ctx, "org", "app", "main", "merge(base,sha)"); err != nil {

--- a/internal/github/ghfake/server.go
+++ b/internal/github/ghfake/server.go
@@ -64,8 +64,12 @@ type Repo struct {
 	Owner, Name   string
 	DefaultBranch string
 
-	PRs       map[int64]*PR
-	Refs      map[string]string // branch -> sha
+	PRs  map[int64]*PR
+	Refs map[string]string // branch -> sha
+	// Parents[sha] lists a commit's parent SHAs. hMerge records the merge
+	// commit's parents here so hUpdateRef can do a real ancestry walk for
+	// its fast-forward check.
+	Parents   map[string][]string
 	CheckRuns map[string][]*CheckRun
 	Rulesets  []*Ruleset
 	// BehindBy["base...head"] feeds GET /compare/{base}...{head}.behind_by.
@@ -164,6 +168,7 @@ func (s *Server) AddRepo(owner, name string) *Repo {
 		DefaultBranch:  "main",
 		PRs:            map[int64]*PR{},
 		Refs:           map[string]string{"main": "sha-main"},
+		Parents:        map[string][]string{},
 		CheckRuns:      map[string][]*CheckRun{},
 		BehindBy:       map[string]int{},
 		ConflictOn:     map[string]bool{},
@@ -646,9 +651,7 @@ func (s *Server) hUpdateRef(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, 403, map[string]any{"message": "Changes must be made through a pull request. (protected branch)"})
 			return
 		}
-		// hMerge encodes lineage as merge(old,head); a SHA that does not
-		// contain the current tip's text is treated as non-fast-forward.
-		if old != body.SHA && !strings.Contains(body.SHA, old) {
+		if !rp.isAncestor(old, body.SHA) {
 			s.mu.Unlock()
 			writeJSON(w, 422, map[string]any{"message": "Update is not a fast forward"})
 			return
@@ -657,6 +660,20 @@ func (s *Server) hUpdateRef(w http.ResponseWriter, r *http.Request) {
 	rp.Refs[branch] = body.SHA
 	s.mu.Unlock()
 	writeJSON(w, 200, map[string]any{"ref": "refs/heads/" + branch, "object": map[string]any{"sha": body.SHA}})
+}
+
+// isAncestor reports whether ancestor is reachable from sha via Parents.
+// Callers must hold s.mu.
+func (rp *Repo) isAncestor(ancestor, sha string) bool {
+	if ancestor == sha {
+		return true
+	}
+	for _, p := range rp.Parents[sha] {
+		if rp.isAncestor(ancestor, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) hDeleteRef(w http.ResponseWriter, r *http.Request) {
@@ -709,6 +726,7 @@ func (s *Server) hMerge(w http.ResponseWriter, r *http.Request) {
 	}
 	// Encode the base SHA so tests can verify the merge used a fresh base.
 	mergeSHA := fmt.Sprintf("merge(%s,%s)", rp.Refs[body.Base], body.Head)
+	rp.Parents[mergeSHA] = []string{rp.Refs[body.Base], body.Head}
 	rp.Refs[body.Base] = mergeSHA
 	writeJSON(w, 201, map[string]any{"sha": mergeSHA})
 }

--- a/internal/logutil/logutil.go
+++ b/internal/logutil/logutil.go
@@ -1,0 +1,12 @@
+// Package logutil holds small logging helpers.
+package logutil
+
+import "log/slog"
+
+// WarnIfErr logs non-nil err at warn level. For best-effort calls whose
+// failure should not abort the caller but must not vanish silently.
+func WarnIfErr(err error, msg string, args ...any) {
+	if err != nil {
+		slog.Warn(msg, append(args, "error", err)...)
+	}
+}

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/logutil"
 	"github.com/Mic92/gitea-mq/internal/queue"
 	"github.com/Mic92/gitea-mq/internal/store/pg"
 )
@@ -42,12 +43,13 @@ func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner,
 	if conflict {
 		slog.Info("merge conflict", "pr", entry.PrNumber)
 
-		_ = f.CancelAutoMerge(ctx, owner, repo, entry.PrNumber)
-		_ = f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
+		logutil.WarnIfErr(f.CancelAutoMerge(ctx, owner, repo, entry.PrNumber), "cancel automerge failed", "pr", entry.PrNumber)
+		logutil.WarnIfErr(f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
 			State: pg.CheckStateFailure, Description: "Merge conflict with target branch", TargetURL: targetURL,
-		})
-		_ = f.Comment(ctx, owner, repo, entry.PrNumber,
-			"❌ Removed from merge queue: merge conflict with target branch. Please rebase and re-schedule automerge.")
+		}), "set mq status failed", "pr", entry.PrNumber)
+		logutil.WarnIfErr(f.Comment(ctx, owner, repo, entry.PrNumber,
+			"❌ Removed from merge queue: merge conflict with target branch. Please rebase and re-schedule automerge."),
+			"post comment failed", "pr", entry.PrNumber)
 
 		if _, err := svc.Dequeue(ctx, repoID, entry.PrNumber); err != nil {
 			return nil, fmt.Errorf("dequeue conflicting PR #%d: %w", entry.PrNumber, err)
@@ -59,12 +61,13 @@ func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner,
 		// user and remove rather than retry silently.
 		slog.Error("merge branch creation failed", "pr", entry.PrNumber, "error", err)
 
-		_ = f.CancelAutoMerge(ctx, owner, repo, entry.PrNumber)
-		_ = f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
+		logutil.WarnIfErr(f.CancelAutoMerge(ctx, owner, repo, entry.PrNumber), "cancel automerge failed", "pr", entry.PrNumber)
+		logutil.WarnIfErr(f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
 			State: pg.CheckStateError, Description: "Failed to create merge branch", TargetURL: targetURL,
-		})
-		_ = f.Comment(ctx, owner, repo, entry.PrNumber,
-			fmt.Sprintf("❌ Removed from merge queue: failed to create merge branch.\n\n```\n%v\n```", err))
+		}), "set mq status failed", "pr", entry.PrNumber)
+		logutil.WarnIfErr(f.Comment(ctx, owner, repo, entry.PrNumber,
+			fmt.Sprintf("❌ Removed from merge queue: failed to create merge branch.\n\n```\n%v\n```", err)),
+			"post comment failed", "pr", entry.PrNumber)
 
 		if _, err := svc.Dequeue(ctx, repoID, entry.PrNumber); err != nil {
 			return nil, fmt.Errorf("dequeue PR #%d after merge error: %w", entry.PrNumber, err)
@@ -83,9 +86,9 @@ func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner,
 	// show outdated results while new CI runs.
 	clearStaleMirroredStatuses(ctx, f, owner, repo, entry.PrHeadSha)
 
-	_ = f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
+	logutil.WarnIfErr(f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
 		State: pg.CheckStatePending, Description: "Testing merge result", TargetURL: targetURL,
-	})
+	}), "set mq status failed", "pr", entry.PrNumber)
 
 	slog.Info("started testing", "pr", entry.PrNumber, "branch", branchName, "sha", mergeSHA)
 
@@ -102,10 +105,10 @@ func clearStaleMirroredStatuses(ctx context.Context, f forge.Forge, owner, repo,
 		if !forge.IsOwnContext(ctxName) {
 			continue
 		}
-		_ = f.MirrorCheck(ctx, owner, repo, sha, ctxName, forge.Check{
+		logutil.WarnIfErr(f.MirrorCheck(ctx, owner, repo, sha, ctxName, forge.Check{
 			State:       pg.CheckStatePending,
 			Description: StaleMirrorDescription,
-		})
+		}), "mirror check reset failed", "sha", sha, "context", ctxName)
 	}
 }
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/logutil"
 	"github.com/Mic92/gitea-mq/internal/merge"
 	"github.com/Mic92/gitea-mq/internal/queue"
 	"github.com/Mic92/gitea-mq/internal/store/pg"
@@ -160,10 +161,10 @@ func skipPendingMirroredStatuses(ctx context.Context, f forge.Forge, owner, repo
 		if c.State != pg.CheckStatePending || c.Description != merge.StaleMirrorDescription {
 			continue
 		}
-		_ = f.MirrorCheck(ctx, owner, repo, sha, ctxName, forge.Check{
+		logutil.WarnIfErr(f.MirrorCheck(ctx, owner, repo, sha, ctxName, forge.Check{
 			State:       forge.CheckState("skipped"),
 			Description: merge.StaleMirrorDescription,
-		})
+		}), "mirror check skip failed", "sha", sha, "context", ctxName)
 	}
 }
 

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Mic92/gitea-mq/internal/batch"
 	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/logutil"
 	"github.com/Mic92/gitea-mq/internal/merge"
 	"github.com/Mic92/gitea-mq/internal/monitor"
 	"github.com/Mic92/gitea-mq/internal/queue"
@@ -90,10 +91,10 @@ func removePR(ctx context.Context, deps *Deps, result *PollResult, entry *pg.Que
 	}
 
 	if opts.cancelAutomerge {
-		_ = deps.Forge.CancelAutoMerge(ctx, deps.Owner, deps.Repo, entry.PrNumber)
+		logutil.WarnIfErr(deps.Forge.CancelAutoMerge(ctx, deps.Owner, deps.Repo, entry.PrNumber), "cancel automerge failed", "pr", entry.PrNumber)
 	}
 	if opts.comment != "" {
-		_ = deps.Forge.Comment(ctx, deps.Owner, deps.Repo, entry.PrNumber, opts.comment)
+		logutil.WarnIfErr(deps.Forge.Comment(ctx, deps.Owner, deps.Repo, entry.PrNumber, opts.comment), "post comment failed", "pr", entry.PrNumber)
 	}
 	// The batch engine owns gitea-mq/batch/<id>; deleting it here can race a
 	// concurrent Build and cause MergeInto to fail with wrong attribution.
@@ -455,10 +456,10 @@ type timedOutRemoval struct {
 // (cancelling automerge and advancing the queue).
 func removeTimedOut(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry, opts timedOutRemoval) {
 	targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, entry.PrNumber)
-	_ = deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, entry.PrHeadSha, forge.MQStatus{
+	logutil.WarnIfErr(deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, entry.PrHeadSha, forge.MQStatus{
 		State: pg.CheckStateError, Description: opts.statusDescription, TargetURL: targetURL,
-	})
-	_ = deps.Queue.SetError(ctx, deps.RepoID, entry.PrNumber, opts.errorMessage)
+	}), "set mq status failed", "pr", entry.PrNumber)
+	logutil.WarnIfErr(deps.Queue.SetError(ctx, deps.RepoID, entry.PrNumber, opts.errorMessage), "set queue error failed", "pr", entry.PrNumber)
 
 	if err := removePR(ctx, deps, result, entry, removeOpts{
 		cancelAutomerge: true,
@@ -536,9 +537,9 @@ func tryFastForwardSuccess(ctx context.Context, deps *Deps, result *PollResult, 
 	}
 
 	targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, head.PrNumber)
-	_ = deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, head.PrHeadSha, forge.MQStatus{
+	logutil.WarnIfErr(deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, head.PrHeadSha, forge.MQStatus{
 		State: pg.CheckStateSuccess, Description: "Already up to date with target branch", TargetURL: targetURL,
-	})
+	}), "set mq status failed", "pr", head.PrNumber)
 	if err := deps.Queue.UpdateState(ctx, deps.RepoID, head.PrNumber, pg.EntryStateSuccess); err != nil {
 		result.Errors = append(result.Errors, fmt.Errorf("update state to success for PR #%d: %w", head.PrNumber, err))
 		return true

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -49,6 +49,22 @@ type Deps struct {
 	// work. Safe only on forges that deliver CI status via webhooks (GitHub);
 	// must stay false for Gitea/Forgejo, which have no commit-status webhook.
 	IdleGating bool
+	// Now overrides the wall clock in timeout checks; nil means time.Now.
+	// Tests use it instead of sleeping past real timeouts.
+	Now func() time.Time
+	// Ticks replaces Run's periodic ticker when non-nil so tests can drive
+	// polls deterministically.
+	Ticks <-chan time.Time
+	// TickDone, when non-nil, is signalled after each trigger/tick has been
+	// fully handled, letting tests sequence polls without sleeping.
+	TickDone chan<- struct{}
+}
+
+func (d *Deps) now() time.Time {
+	if d.Now != nil {
+		return d.Now()
+	}
+	return time.Now()
 }
 
 type PollResult struct {
@@ -386,7 +402,7 @@ func reconcileEntries(ctx context.Context, deps *Deps, result *PollResult, openP
 // merged by the forge within SuccessTimeout, which usually points at a branch
 // protection misconfiguration.
 func handleSuccessTimeout(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry) {
-	if entry.State != pg.EntryStateSuccess || !timedOut(entry.CompletedAt, deps.SuccessTimeout) {
+	if entry.State != pg.EntryStateSuccess || !timedOut(deps.now(), entry.CompletedAt, deps.SuccessTimeout) {
 		return
 	}
 
@@ -408,7 +424,7 @@ func handleTestingTimeout(ctx context.Context, deps *Deps, result *PollResult, e
 	if entry.ActiveBatchID.Valid {
 		return
 	}
-	if entry.State != pg.EntryStateTesting || !timedOut(entry.TestingStartedAt, deps.CheckTimeout) {
+	if entry.State != pg.EntryStateTesting || !timedOut(deps.now(), entry.TestingStartedAt, deps.CheckTimeout) {
 		return
 	}
 
@@ -421,10 +437,10 @@ func handleTestingTimeout(ctx context.Context, deps *Deps, result *PollResult, e
 	})
 }
 
-// timedOut reports whether ts is set and lies more than timeout in the past.
+// timedOut reports whether ts is set and lies more than timeout before now.
 // A non-positive timeout disables the check.
-func timedOut(ts pgtype.Timestamptz, timeout time.Duration) bool {
-	return timeout > 0 && ts.Valid && time.Since(ts.Time) > timeout
+func timedOut(now time.Time, ts pgtype.Timestamptz, timeout time.Duration) bool {
+	return timeout > 0 && ts.Valid && now.Sub(ts.Time) > timeout
 }
 
 // timedOutRemoval describes how a timed-out entry is reported before removal.
@@ -543,6 +559,12 @@ func hasActiveWork(ctx context.Context, deps *Deps) bool {
 	return len(entries) > 0
 }
 
+func notifyTickDone(deps *Deps) {
+	if deps.TickDone != nil {
+		deps.TickDone <- struct{}{}
+	}
+}
+
 // Run starts the polling loop. The first poll happens immediately. idleInterval
 // throttles reconciles for idle repos only when deps.IdleGating is set.
 func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) {
@@ -574,8 +596,12 @@ func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) 
 	if idleInterval < interval {
 		idleInterval = interval
 	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	ticks := deps.Ticks
+	if ticks == nil {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		ticks = ticker.C
+	}
 	lastFull := time.Now()
 
 	for {
@@ -586,12 +612,14 @@ func Run(ctx context.Context, deps *Deps, interval, idleInterval time.Duration) 
 		case <-deps.Trigger:
 			doPoll(false)
 			lastFull = time.Now()
-		case <-ticker.C:
-			if deps.IdleGating && !hasActiveWork(ctx, deps) && time.Since(lastFull) < idleInterval {
-				continue
+			notifyTickDone(deps)
+		case <-ticks:
+			skipIdle := deps.IdleGating && !hasActiveWork(ctx, deps) && time.Since(lastFull) < idleInterval
+			if !skipIdle {
+				doPoll(true)
+				lastFull = time.Now()
 			}
-			doPoll(true)
-			lastFull = time.Now()
+			notifyTickDone(deps)
 		}
 	}
 }

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -52,15 +52,25 @@ func mockAutomergePRs(mock *gitea.MockClient, prs ...gitea.PR) {
 	}
 }
 
-// runPollerFor runs poller.Run with the given intervals until wait elapses.
-func runPollerFor(ctx context.Context, deps *poller.Deps, tick, idle, wait time.Duration) {
+// runPollerTicks runs poller.Run driven by an injected tick channel and
+// delivers n ticks, waiting for each to be fully handled via TickDone, so no
+// wall-clock sleeps and no ticks racing cancellation.
+func runPollerTicks(ctx context.Context, deps *poller.Deps, n int) {
+	ticks := make(chan time.Time)
+	tickDone := make(chan struct{})
+	deps.Ticks = ticks
+	deps.TickDone = tickDone
+
 	runCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
-		poller.Run(runCtx, deps, tick, idle)
+		poller.Run(runCtx, deps, time.Hour, time.Hour)
 		close(done)
 	}()
-	time.Sleep(wait)
+	for range n {
+		ticks <- time.Now()
+		<-tickDone
+	}
 	cancel()
 	<-done
 }
@@ -372,7 +382,8 @@ func TestPollOnce_Timeouts(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = svc.UpdateState(ctx, repoID, 42, tc.state)
-			time.Sleep(5 * time.Millisecond)
+			// Fake clock past the 1ms timeout instead of sleeping.
+			deps.Now = func() time.Time { return time.Now().Add(time.Second) }
 
 			mockAutomergePRs(mock, makePR(42, "sha42", "main"))
 
@@ -538,8 +549,8 @@ func TestRun_IdleRepoSkipsPeriodicPoll(t *testing.T) {
 		return nil, nil
 	}
 
-	// Fast tick, long idle interval: idle repo polls only at startup.
-	runPollerFor(ctx, deps, 5*time.Millisecond, time.Hour, 100*time.Millisecond)
+	// Long idle interval: idle repo polls only at startup despite ticks.
+	runPollerTicks(ctx, deps, 5)
 
 	if listed != 1 {
 		t.Fatalf("idle repo polled forge %d times, want 1 (startup only)", listed)
@@ -559,7 +570,7 @@ func TestRun_NoIdleGatingPollsEveryTick(t *testing.T) {
 		return nil, nil
 	}
 
-	runPollerFor(ctx, deps, 5*time.Millisecond, time.Hour, 60*time.Millisecond)
+	runPollerTicks(ctx, deps, 4)
 
 	// Startup poll plus several periodic polls despite the repo being idle.
 	if listed < 3 {
@@ -573,8 +584,13 @@ func TestRun_TriggerPollsIdleRepo(t *testing.T) {
 	deps, mock, _, ctx, _ := setupPollerTest(t)
 	deps.IdleGating = true
 
-	trigger := make(chan struct{}, 1)
+	trigger := make(chan struct{})
 	deps.Trigger = trigger
+
+	// TickDone tells us when the triggered poll finished; the real ticker
+	// (1h interval) never fires within the test.
+	tickDone := make(chan struct{})
+	deps.TickDone = tickDone
 
 	var listed int
 	mock.ListOpenPRsFn = func(_ context.Context, _, _ string) ([]gitea.PR, error) {
@@ -591,10 +607,10 @@ func TestRun_TriggerPollsIdleRepo(t *testing.T) {
 		close(done)
 	}()
 
-	// Let the startup poll settle, then fire a webhook-style trigger.
-	time.Sleep(20 * time.Millisecond)
+	// Fire a webhook-style trigger and wait until it is fully handled so the
+	// poll count is deterministic.
 	trigger <- struct{}{}
-	time.Sleep(50 * time.Millisecond)
+	<-tickDone
 	cancel()
 	<-done
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -242,6 +242,16 @@ func (s *Service) List(ctx context.Context, repoID int64, targetBranch string) (
 	return entries, nil
 }
 
+// Position returns the PR's 1-based position among active entries for its
+// target branch, or 0 when the PR is not queued.
+func (s *Service) Position(ctx context.Context, repoID int64, targetBranch string, prNumber int64) (int64, error) {
+	return s.queries().CountQueuePosition(ctx, pg.CountQueuePositionParams{
+		RepoID:       repoID,
+		TargetBranch: targetBranch,
+		PrNumber:     prNumber,
+	})
+}
+
 // UpdateState transitions a queue entry to a new state.
 func (s *Service) UpdateState(ctx context.Context, repoID, prNumber int64, state pg.EntryState) error {
 	return s.queries().UpdateEntryState(ctx, pg.UpdateEntryStateParams{

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -274,3 +274,47 @@ func TestLoadActiveQueuesExcludesTerminal(t *testing.T) {
 		t.Fatalf("expected only PR #10 active, got %v", active)
 	}
 }
+
+// Position is scoped to the target branch and ignores terminal entries.
+func TestPosition(t *testing.T) {
+	svc, ctx, repoID := testutil.TestQueueService(t)
+
+	for _, pr := range []int64{10, 20, 30} {
+		if _, err := svc.Enqueue(ctx, repoID, pr, "sha", "main"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Different branch must not count towards main's positions.
+	if _, err := svc.Enqueue(ctx, repoID, 40, "sha", "release"); err != nil {
+		t.Fatal(err)
+	}
+
+	pos, err := svc.Position(ctx, repoID, "main", 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 3 {
+		t.Fatalf("PR #30 position = %d, want 3", pos)
+	}
+
+	// A failed entry ahead in the queue no longer occupies a position.
+	if err := svc.UpdateState(ctx, repoID, 10, pg.EntryStateFailed); err != nil {
+		t.Fatal(err)
+	}
+	pos, err = svc.Position(ctx, repoID, "main", 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 2 {
+		t.Fatalf("PR #30 position after failure ahead = %d, want 2", pos)
+	}
+
+	// Unknown PR reports position 0.
+	pos, err = svc.Position(ctx, repoID, "main", 99)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 0 {
+		t.Fatalf("unknown PR position = %d, want 0", pos)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -170,7 +170,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		CheckTimeout:        r.deps.CheckTimeout,
 		SkipQueueIfUpToDate: r.deps.SkipQueueIfUpToDate,
 		Batch:               batchEngine,
-		IdleGating:          f.Kind() == forge.KindGithub,
+		IdleGating:          f.Capabilities().StatusWebhook,
 	}
 	go poller.Run(pollerCtx, pollerDeps, r.deps.PollInterval, r.deps.IdlePollInterval)
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,6 +7,8 @@ package registry
 import (
 	"context"
 	"log/slog"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -259,6 +261,9 @@ func (r *RepoRegistry) List() []forge.RepoRef {
 	for _, m := range r.repos {
 		refs = append(refs, m.Ref)
 	}
+	slices.SortFunc(refs, func(a, b forge.RepoRef) int {
+		return strings.Compare(a.String(), b.String())
+	})
 	return refs
 }
 

--- a/internal/store/pg/query.sql
+++ b/internal/store/pg/query.sql
@@ -71,7 +71,10 @@ LIMIT 1;
 -- name: CountQueuePosition :one
 SELECT COUNT(*) FROM queue_entries qe
 WHERE qe.repo_id = $1 AND qe.target_branch = $2
-  AND qe.enqueued_at <= (SELECT qe2.enqueued_at FROM queue_entries qe2 WHERE qe2.repo_id = $1 AND qe2.pr_number = $3);
+  AND qe.state NOT IN ('failed', 'cancelled')
+  AND qe.enqueued_at <= (SELECT qe2.enqueued_at FROM queue_entries qe2
+                         WHERE qe2.repo_id = $1 AND qe2.pr_number = $3
+                           AND qe2.state NOT IN ('failed', 'cancelled'));
 
 -- name: DequeueAllByRepo :exec
 DELETE FROM queue_entries

--- a/internal/store/pg/query.sql.go
+++ b/internal/store/pg/query.sql.go
@@ -45,7 +45,10 @@ func (q *Queries) ClearEntryMergeBranch(ctx context.Context, ids []int64) error 
 const countQueuePosition = `-- name: CountQueuePosition :one
 SELECT COUNT(*) FROM queue_entries qe
 WHERE qe.repo_id = $1 AND qe.target_branch = $2
-  AND qe.enqueued_at <= (SELECT qe2.enqueued_at FROM queue_entries qe2 WHERE qe2.repo_id = $1 AND qe2.pr_number = $3)
+  AND qe.state NOT IN ('failed', 'cancelled')
+  AND qe.enqueued_at <= (SELECT qe2.enqueued_at FROM queue_entries qe2
+                         WHERE qe2.repo_id = $1 AND qe2.pr_number = $3
+                           AND qe2.state NOT IN ('failed', 'cancelled'))
 `
 
 type CountQueuePositionParams struct {

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -400,18 +400,11 @@ func servePRDetail(w http.ResponseWriter, r *http.Request, deps *Deps, ref forge
 		data.EnqueuedAt = entry.EnqueuedAt.Time.UTC()
 	}
 
-	// Determine queue position.
-	entries, err := deps.Queue.ListActiveEntries(ctx, repo.ID)
+	pos, err := deps.Queue.Position(ctx, repo.ID, entry.TargetBranch, prNumber)
 	if err != nil {
-		slog.Error("failed to list active entries", "error", err)
-	} else {
-		for i, e := range entries {
-			if e.PrNumber == prNumber {
-				data.Position = i + 1
-				break
-			}
-		}
+		slog.Error("failed to compute queue position", "pr", prNumber, "error", err)
 	}
+	data.Position = int(pos)
 
 	// Fetch PR title/author from the forge (graceful degradation).
 	f := forgeFor(deps, ref)


### PR DESCRIPTION

The poller unit tests relied on real time: timeout tests slept 5ms past
1ms timeouts and the Run tests slept 60-100ms around a real ticker,
which gets flaky under CI load.

Inject the clock and the tick source instead: Deps.Now overrides the
wall clock used by timedOut(), Deps.Ticks replaces Run's periodic
ticker, and Deps.TickDone signals when a trigger/tick was fully handled
so tests can sequence polls without sleeping or racing cancellation.
