### PR TITLE
gitea: enable idle gating when the server has commit-status webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ larger suite than PR CI).
 
 ## Requirements
 
-- Gitea >= 1.22 and/or a GitHub App
+- Gitea >= 1.22 and/or a GitHub App. With Gitea >= 1.24 (or a Forgejo release
+  based on it) CI results arrive via the commit-status webhook and idle repos
+  are only reconciled every `GITEA_MQ_IDLE_POLL_INTERVAL`; older versions fall
+  back to polling every `GITEA_MQ_POLL_INTERVAL`.
 - PostgreSQL
 - For Gitea: an API token with repo read/write permissions
 
@@ -54,7 +57,7 @@ variables.
 | `GITEA_MQ_WEBHOOK_PATH` | no | `/webhook` | Legacy alias for the Gitea webhook endpoint (the canonical path is `/webhook/gitea`) |
 | `GITEA_MQ_EXTERNAL_URL` | yes | - | URL where Gitea can reach this service (used for webhook auto-setup and commit status target URLs) |
 | `GITEA_MQ_POLL_INTERVAL` | no | `30s` | Reconcile poll interval for repos with active queue work |
-| `GITEA_MQ_IDLE_POLL_INTERVAL` | no | `15m` | Reconcile poll interval for idle repos (no active queue entries). Idle repos are driven by webhooks; this periodic poll is only a safety net for deliveries missed while the service was down. Keeping it long bounds forge API usage to the number of repos with live queues rather than all managed repos |
+| `GITEA_MQ_IDLE_POLL_INTERVAL` | no | `15m` | Reconcile poll interval for idle repos (no active queue entries). Only used on forges that deliver CI status via webhooks (GitHub, Gitea >= 1.24); there idle repos are driven by webhooks and this periodic poll is just a safety net for deliveries missed while the service was down. Keeping it long bounds forge API usage to the number of repos with live queues rather than all managed repos |
 | `GITEA_MQ_CHECK_TIMEOUT` | no | `1h` | Timeout for required checks |
 | `GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE` | no | `true` | Skip the merge-branch CI run when a PR is already rebased onto the target branch tip (its own green CI already covers the merged tree) |
 | `GITEA_MQ_REQUIRED_CHECKS` | no | - | Fallback required CI contexts when branch protection has none (comma-separated) |

--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -247,4 +247,8 @@ type Client interface {
 	// CreateWebhook creates a webhook on a repository.
 	// POST /repos/{owner}/{repo}/hooks
 	CreateWebhook(ctx context.Context, owner, repo string, opts CreateWebhookOpts) error
+
+	// ServerVersion returns the Gitea/Forgejo server version string.
+	// GET /version
+	ServerVersion(ctx context.Context) (string, error)
 }

--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -251,4 +251,8 @@ type Client interface {
 	// ServerVersion returns the Gitea/Forgejo server version string.
 	// GET /version
 	ServerVersion(ctx context.Context) (string, error)
+
+	// IsForgejo reports whether the server is a Forgejo instance.
+	// GET /api/forgejo/v1/version (200 on Forgejo, 404 on Gitea)
+	IsForgejo(ctx context.Context) (bool, error)
 }

--- a/internal/gitea/forge.go
+++ b/internal/gitea/forge.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Mic92/gitea-mq/internal/forge"
 )
@@ -15,6 +18,9 @@ import (
 type giteaForge struct {
 	client  Client
 	baseURL string
+
+	capsOnce sync.Once
+	caps     forge.Capabilities
 }
 
 // NewForge wraps a Gitea Client as a forge.Forge. baseURL is the Gitea
@@ -46,9 +52,22 @@ func (f *giteaForge) StackMerges(ctx context.Context, owner, repo, base string, 
 
 func (f *giteaForge) Kind() forge.Kind { return forge.KindGitea }
 
-// Gitea/Forgejo have no commit-status webhook; CI results are polled.
+// Capabilities probes the server version once: Gitea >= 1.24 delivers
+// commit-status webhooks, older Gitea and Forgejo must be polled. On probe
+// failure it stays at the polling default.
 func (f *giteaForge) Capabilities() forge.Capabilities {
-	return forge.Capabilities{StatusWebhook: false}
+	f.capsOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		version, err := f.client.ServerVersion(ctx)
+		if err != nil {
+			slog.Warn("gitea: server version probe failed, assuming no status webhook", "error", err)
+			return
+		}
+		f.caps.StatusWebhook = supportsStatusWebhook(version)
+		slog.Info("gitea: server capabilities detected", "version", version, "status_webhook", f.caps.StatusWebhook)
+	})
+	return f.caps
 }
 
 func (f *giteaForge) RepoHTMLURL(owner, name string) string {

--- a/internal/gitea/forge.go
+++ b/internal/gitea/forge.go
@@ -52,13 +52,22 @@ func (f *giteaForge) StackMerges(ctx context.Context, owner, repo, base string, 
 
 func (f *giteaForge) Kind() forge.Kind { return forge.KindGitea }
 
-// Capabilities probes the server version once: Gitea >= 1.24 delivers
-// commit-status webhooks, older Gitea and Forgejo must be polled. On probe
-// failure it stays at the polling default.
+// Capabilities probes the server once: Forgejo (detected via its dedicated
+// API root) never delivers commit-status webhooks; Gitea >= 1.24 does. On
+// probe failure it stays at the polling default.
 func (f *giteaForge) Capabilities() forge.Capabilities {
 	f.capsOnce.Do(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
+		isForgejo, err := f.client.IsForgejo(ctx)
+		if err != nil {
+			slog.Warn("gitea: forgejo probe failed, assuming no status webhook", "error", err)
+			return
+		}
+		if isForgejo {
+			slog.Info("gitea: server capabilities detected", "forgejo", true, "status_webhook", false)
+			return
+		}
 		version, err := f.client.ServerVersion(ctx)
 		if err != nil {
 			slog.Warn("gitea: server version probe failed, assuming no status webhook", "error", err)

--- a/internal/gitea/forge_test.go
+++ b/internal/gitea/forge_test.go
@@ -250,3 +250,33 @@ func TestForge_URLHelpers(t *testing.T) {
 		t.Errorf("BranchHTMLURL = %q", got)
 	}
 }
+
+func TestForge_Capabilities(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		err     error
+		want    bool
+	}{
+		{"gitea 1.24", "1.24.2", nil, true},
+		{"gitea 1.23", "1.23.5", nil, false},
+		{"forgejo compat 1.22", "11.0.1+gitea-1.22.0", nil, false},
+		{"probe failure", "", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &gitea.MockClient{
+				ServerVersionFn: func(context.Context) (string, error) { return tc.version, tc.err },
+			}
+			f := newForge(mock)
+			if got := f.Capabilities().StatusWebhook; got != tc.want {
+				t.Fatalf("StatusWebhook = %v, want %v", got, tc.want)
+			}
+			// Result is cached; a second call must not probe again.
+			f.Capabilities()
+			if calls := len(mock.CallsTo("ServerVersion")); calls != 1 {
+				t.Fatalf("ServerVersion calls = %d, want 1", calls)
+			}
+		})
+	}
+}

--- a/internal/gitea/forge_test.go
+++ b/internal/gitea/forge_test.go
@@ -253,19 +253,23 @@ func TestForge_URLHelpers(t *testing.T) {
 
 func TestForge_Capabilities(t *testing.T) {
 	cases := []struct {
-		name    string
-		version string
-		err     error
-		want    bool
+		name       string
+		forgejo    bool
+		forgejoErr error
+		version    string
+		err        error
+		want       bool
 	}{
-		{"gitea 1.24", "1.24.2", nil, true},
-		{"gitea 1.23", "1.23.5", nil, false},
-		{"forgejo compat 1.22", "11.0.1+gitea-1.22.0", nil, false},
-		{"probe failure", "", errors.New("boom"), false},
+		{name: "gitea 1.24", version: "1.24.2", want: true},
+		{name: "gitea 1.23", version: "1.23.5", want: false},
+		{name: "forgejo", forgejo: true, version: "15.0.3", want: false},
+		{name: "forgejo probe failure", forgejoErr: errors.New("boom"), version: "1.24.2", want: false},
+		{name: "version probe failure", err: errors.New("boom"), want: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := &gitea.MockClient{
+				IsForgejoFn:     func(context.Context) (bool, error) { return tc.forgejo, tc.forgejoErr },
 				ServerVersionFn: func(context.Context) (string, error) { return tc.version, tc.err },
 			}
 			f := newForge(mock)
@@ -274,8 +278,8 @@ func TestForge_Capabilities(t *testing.T) {
 			}
 			// Result is cached; a second call must not probe again.
 			f.Capabilities()
-			if calls := len(mock.CallsTo("ServerVersion")); calls != 1 {
-				t.Fatalf("ServerVersion calls = %d, want 1", calls)
+			if calls := len(mock.CallsTo("IsForgejo")); calls != 1 {
+				t.Fatalf("IsForgejo calls = %d, want 1", calls)
 			}
 		})
 	}

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -647,5 +647,21 @@ func (c *HTTPClient) CreateWebhook(ctx context.Context, owner, repo string, opts
 		fmt.Sprintf("create webhook in %s/%s", owner, repo))
 }
 
+// ServerVersion returns the Gitea/Forgejo server version string.
+// GET /version
+func (c *HTTPClient) ServerVersion(ctx context.Context) (string, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/version", nil)
+	if err != nil {
+		return "", err
+	}
+	var v struct {
+		Version string `json:"version"`
+	}
+	if err := c.decodeJSON(resp, &v); err != nil {
+		return "", fmt.Errorf("get server version: %w", err)
+	}
+	return v.Version, nil
+}
+
 // Ensure HTTPClient implements Client at compile time.
 var _ Client = (*HTTPClient)(nil)

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -663,5 +663,35 @@ func (c *HTTPClient) ServerVersion(ctx context.Context) (string, error) {
 	return v.Version, nil
 }
 
+// IsForgejo reports whether the server is a Forgejo instance by probing the
+// Forgejo-only API root: GET /api/forgejo/v1/version returns 200 on Forgejo
+// and 404 on Gitea.
+func (c *HTTPClient) IsForgejo(ctx context.Context) (bool, error) {
+	url := c.baseURL + "/api/forgejo/v1/version"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+c.token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("probe forgejo version endpoint: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("failed to close response body", "error", err)
+		}
+	}()
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return true, nil
+	case resp.StatusCode == http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("probe forgejo version endpoint: unexpected status %d", resp.StatusCode)
+	}
+}
+
 // Ensure HTTPClient implements Client at compile time.
 var _ Client = (*HTTPClient)(nil)

--- a/internal/gitea/mock.go
+++ b/internal/gitea/mock.go
@@ -42,6 +42,7 @@ type MockClient struct {
 	EditBranchProtectionFn    func(ctx context.Context, owner, repo, name string, opts EditBranchProtectionOpts) error
 	ListWebhooksFn            func(ctx context.Context, owner, repo string) ([]Webhook, error)
 	CreateWebhookFn           func(ctx context.Context, owner, repo string, opts CreateWebhookOpts) error
+	ServerVersionFn           func(ctx context.Context) (string, error)
 }
 
 // Ensure MockClient implements Client at compile time.
@@ -283,4 +284,14 @@ func (m *MockClient) CreateWebhook(ctx context.Context, owner, repo string, opts
 	}
 
 	return nil
+}
+
+func (m *MockClient) ServerVersion(ctx context.Context) (string, error) {
+	m.record("ServerVersion")
+
+	if m.ServerVersionFn != nil {
+		return m.ServerVersionFn(ctx)
+	}
+
+	return "", nil
 }

--- a/internal/gitea/mock.go
+++ b/internal/gitea/mock.go
@@ -43,6 +43,7 @@ type MockClient struct {
 	ListWebhooksFn            func(ctx context.Context, owner, repo string) ([]Webhook, error)
 	CreateWebhookFn           func(ctx context.Context, owner, repo string, opts CreateWebhookOpts) error
 	ServerVersionFn           func(ctx context.Context) (string, error)
+	IsForgejoFn               func(ctx context.Context) (bool, error)
 }
 
 // Ensure MockClient implements Client at compile time.
@@ -294,4 +295,14 @@ func (m *MockClient) ServerVersion(ctx context.Context) (string, error) {
 	}
 
 	return "", nil
+}
+
+func (m *MockClient) IsForgejo(ctx context.Context) (bool, error) {
+	m.record("IsForgejo")
+
+	if m.IsForgejoFn != nil {
+		return m.IsForgejoFn(ctx)
+	}
+
+	return false, nil
 }

--- a/internal/gitea/version.go
+++ b/internal/gitea/version.go
@@ -1,0 +1,22 @@
+package gitea
+
+import (
+	"fmt"
+	"strings"
+)
+
+// supportsStatusWebhook reports whether a Gitea server at the given version
+// delivers commit-status webhook events (added in Gitea 1.24). Forgejo
+// versions carry a "+gitea-x.y.z" compatibility suffix; that compat version
+// is what counts.
+func supportsStatusWebhook(version string) bool {
+	base, suffix, _ := strings.Cut(version, "+")
+	if compat, ok := strings.CutPrefix(suffix, "gitea-"); ok {
+		base = compat
+	}
+	var major, minor int
+	if _, err := fmt.Sscanf(base, "%d.%d", &major, &minor); err != nil {
+		return false
+	}
+	return major > 1 || (major == 1 && minor >= 24)
+}

--- a/internal/gitea/version_test.go
+++ b/internal/gitea/version_test.go
@@ -1,0 +1,28 @@
+package gitea
+
+import "testing"
+
+func TestSupportsStatusWebhook(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"1.24.0", true},
+		{"1.25.1", true},
+		{"2.0.0", true},
+		{"1.24.0+dev-123-gabcdef", true},
+		{"1.23.5", false},
+		{"1.9.4", false},
+		// Forgejo reports its own version with a Gitea compat suffix; the
+		// compat version decides.
+		{"11.0.1+gitea-1.22.0", false},
+		{"12.0.0+gitea-1.24.0", true},
+		{"", false},
+		{"garbage", false},
+	}
+	for _, tc := range cases {
+		if got := supportsStatusWebhook(tc.version); got != tc.want {
+			t.Errorf("supportsStatusWebhook(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -47,8 +47,8 @@ type Deps struct {
 	// path is taken when nil so BATCH_MAX=1 stays byte-for-byte unchanged.
 	Batch *batch.Engine
 	// IdleGating lets the periodic reconcile skip repos with no live queue
-	// work. Safe only on forges that deliver CI status via webhooks (GitHub);
-	// must stay false for Gitea/Forgejo, which have no commit-status webhook.
+	// work. Safe only on forges that deliver CI status via webhooks (GitHub,
+	// Gitea >= 1.24); must stay false for forges that need status polling.
 	IdleGating bool
 	// Now overrides the wall clock in timeout checks; nil means time.Now.
 	// Tests use it instead of sleeping past real timeouts.


### PR DESCRIPTION

Gitea 1.24 added the 'status' webhook event, which gitea-mq already
subscribes to and handles; only the capability flag still assumed
polling-only. Probe GET /version once and report StatusWebhook for
Gitea >= 1.24 (Forgejo's +gitea-x.y compat suffix decides), so the idle
poller backs off on such servers. Older servers keep polling, and the
status poll remains as fallback for missed deliveries.
