### PR TITLE
poller: defer success timeout while PR-head checks are pending

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -111,17 +111,17 @@ func removePR(ctx context.Context, deps *Deps, result *PollResult, entry *pg.Que
 	return nil
 }
 
-// prChecksGreen reports whether the PR's own head-commit checks are passing.
-// True when all required checks pass, or when no CI is configured at all.
-func prChecksGreen(ctx context.Context, deps *Deps, pr *forge.PR) (bool, error) {
+// prCheckResult evaluates the PR's own head-commit checks against the
+// required checks. Reports CheckSuccess when no CI is configured at all.
+func prCheckResult(ctx context.Context, deps *Deps, pr *forge.PR) (monitor.CheckResult, error) {
 	requiredChecks, err := monitor.ResolveRequiredChecks(ctx, deps.Forge, deps.Owner, deps.Repo, pr.BaseBranch, deps.FallbackChecks)
 	if err != nil {
-		return false, fmt.Errorf("resolve required checks for PR #%d: %w", pr.Number, err)
+		return monitor.CheckWaiting, fmt.Errorf("resolve required checks for PR #%d: %w", pr.Number, err)
 	}
 
 	checks, err := deps.Forge.GetCheckStates(ctx, deps.Owner, deps.Repo, pr.HeadSHA)
 	if err != nil {
-		return false, fmt.Errorf("get check states for PR #%d: %w", pr.Number, err)
+		return monitor.CheckWaiting, fmt.Errorf("get check states for PR #%d: %w", pr.Number, err)
 	}
 
 	// gitea-mq/* mirrors are our own output, not external CI.
@@ -134,11 +134,11 @@ func prChecksGreen(ctx context.Context, deps *Deps, pr *forge.PR) (bool, error) 
 	}
 
 	if len(requiredChecks) == 0 && len(externalStatuses) == 0 {
-		return true, nil
+		return monitor.CheckSuccess, nil
 	}
 
 	res, _, _ := monitor.EvaluateChecks(externalStatuses, requiredChecks)
-	return res == monitor.CheckSuccess, nil
+	return res, nil
 }
 
 // PollOnce runs a single reconcile cycle for one repository.
@@ -282,12 +282,12 @@ func enqueueAutoMergePRs(ctx context.Context, deps *Deps, result *PollResult, op
 			continue
 		}
 
-		green, err := prChecksGreen(ctx, deps, pr)
+		res, err := prCheckResult(ctx, deps, pr)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("check CI status for PR #%d: %w", pr.Number, err))
 			continue
 		}
-		if !green {
+		if res != monitor.CheckSuccess {
 			continue
 		}
 
@@ -394,17 +394,29 @@ func reconcileEntries(ctx context.Context, deps *Deps, result *PollResult, openP
 			}
 			continue
 		}
-		handleSuccessTimeout(ctx, deps, result, &entry)
+		handleSuccessTimeout(ctx, deps, result, &entry, pr)
 		handleTestingTimeout(ctx, deps, result, &entry)
 	}
 }
 
 // handleSuccessTimeout removes entries that reported success but were never
 // merged by the forge within SuccessTimeout, which usually points at a branch
-// protection misconfiguration.
-func handleSuccessTimeout(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry) {
+// protection misconfiguration. While the PR's own required checks are still
+// pending the forge legitimately cannot merge yet, so removal is deferred —
+// but only up to CheckTimeout, so a stuck CI cannot block the queue forever.
+func handleSuccessTimeout(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry, pr *forge.PR) {
 	if entry.State != pg.EntryStateSuccess || !timedOut(deps.now(), entry.CompletedAt, deps.SuccessTimeout) {
 		return
+	}
+
+	if pr != nil && !timedOut(deps.now(), entry.CompletedAt, deps.CheckTimeout) {
+		res, err := prCheckResult(ctx, deps, pr)
+		if err != nil {
+			slog.Warn("success timeout: could not evaluate PR checks", "pr", entry.PrNumber, "error", err)
+		} else if res == monitor.CheckWaiting {
+			slog.Info("success timeout deferred: PR checks still pending", "pr", entry.PrNumber)
+			return
+		}
 	}
 
 	removeTimedOut(ctx, deps, result, entry, timedOutRemoval{

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -405,6 +405,56 @@ func TestPollOnce_Timeouts(t *testing.T) {
 	}
 }
 
+// A PR in "success" whose own required checks are still running cannot be
+// merged by the forge yet, so the success timeout must wait for them — but
+// only up to CheckTimeout, so a stuck CI cannot block the queue forever.
+func TestPollOnce_SuccessTimeoutWaitsForPendingPRChecks(t *testing.T) {
+	cases := []struct {
+		name         string
+		clockAdvance time.Duration
+		wantDequeued bool
+	}{
+		{name: "pr_ci_still_running", clockAdvance: time.Second, wantDequeued: false},
+		{name: "pr_ci_stuck_past_check_timeout", clockAdvance: 2 * time.Hour, wantDequeued: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps, mock, svc, ctx, repoID := setupPollerTest(t)
+			deps.SuccessTimeout = 1 * time.Millisecond
+			deps.CheckTimeout = 1 * time.Hour
+			deps.FallbackChecks = []string{"ci/build"}
+
+			if _, err := svc.Enqueue(ctx, repoID, 42, "sha42", "main"); err != nil {
+				t.Fatal(err)
+			}
+			_ = svc.UpdateState(ctx, repoID, 42, pg.EntryStateSuccess)
+			deps.Now = func() time.Time { return time.Now().Add(tc.clockAdvance) }
+
+			mockAutomergePRs(mock, makePR(42, "sha42", "main"))
+			mock.GetCombinedCommitStatusFn = func(_ context.Context, _, _, _ string) (*gitea.CombinedStatus, error) {
+				return &gitea.CombinedStatus{
+					State:    "pending",
+					Statuses: []gitea.CommitStatusResult{{Context: "ci/build", Status: "pending"}},
+				}, nil
+			}
+
+			result, err := poller.PollOnce(ctx, deps)
+			if err != nil {
+				t.Fatalf("PollOnce: %v", err)
+			}
+
+			gotDequeued := len(result.Dequeued) == 1 && result.Dequeued[0] == 42
+			if gotDequeued != tc.wantDequeued {
+				t.Fatalf("dequeued=%v, want %v (result: %v)", gotDequeued, tc.wantDequeued, result.Dequeued)
+			}
+			if !tc.wantDequeued && len(mock.CallsTo("CancelAutoMerge")) != 0 {
+				t.Fatal("automerge must stay enabled while PR CI is pending")
+			}
+		})
+	}
+}
+
 // prChecksGreen gating: only enqueue once required checks (or none) are green.
 func TestPollOnce_CIGating(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Fixes the false "Removed from merge queue: ... branch protection issue" comment (see Mic92/dotfiles#5744): the PR's own required checks were still running, so the forge could not merge yet. The poller now waits while those checks are pending, bounded by CheckTimeout so a stuck CI cannot block the queue forever.