### PR TITLE
drop x86_64-darwin from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
       eachSystem = lib.genAttrs systems;


### PR DESCRIPTION

no longer supported by nixpkgs
