### PR TITLE
github: evaluate latest check run per context

### DIFF
--- a/internal/github/forge.go
+++ b/internal/github/forge.go
@@ -124,6 +124,7 @@ func (f *githubForge) GetCheckStates(ctx context.Context, owner, name, sha strin
 		return nil, err
 	}
 	out := map[string]forge.Check{}
+	latestRunIDs := map[string]int64{}
 
 	opts := &gh.ListCheckRunsOptions{ListOptions: gh.ListOptions{PerPage: 100}}
 	for cr, err := range c.Checks.ListCheckRunsForRefIter(ctx, owner, name, sha, opts) {
@@ -134,6 +135,13 @@ func (f *githubForge) GetCheckStates(ctx context.Context, owner, name, sha strin
 		if cr.GetName() == forge.MQContext {
 			continue
 		}
+		// Retries and concurrency cancellation can leave multiple runs for one
+		// context. GitHub evaluates the newest run, so do not let an older run
+		// overwrite its state when API pages contain both.
+		if latestID, ok := latestRunIDs[cr.GetName()]; ok && cr.GetID() < latestID {
+			continue
+		}
+		latestRunIDs[cr.GetName()] = cr.GetID()
 		out[cr.GetName()] = forge.Check{
 			State:       CheckRunToState(cr.GetStatus(), cr.GetConclusion()),
 			Description: cr.GetOutput().GetSummary(),

--- a/internal/github/forge_test.go
+++ b/internal/github/forge_test.go
@@ -130,6 +130,22 @@ func TestForge_GetCheckStates_MapsRunsAndExcludesSelf(t *testing.T) {
 	}
 }
 
+func TestForge_GetCheckStates_PrefersLatestRunForContext(t *testing.T) {
+	srv, f := newTestForge(t)
+	srv.Repo("org", "app").CheckRuns["abc"] = []*ghfake.CheckRun{
+		{ID: 2, Name: "ci/build", Status: "completed", Conclusion: "success", DetailsURL: "https://ci/latest"},
+		{ID: 1, Name: "ci/build", Status: "completed", Conclusion: "cancelled", DetailsURL: "https://ci/old"},
+	}
+
+	got, err := f.GetCheckStates(context.Background(), "org", "app", "abc")
+	if err != nil {
+		t.Fatalf("GetCheckStates: %v", err)
+	}
+	if got["ci/build"].State != pg.CheckStateSuccess || got["ci/build"].TargetURL != "https://ci/latest" {
+		t.Errorf("ci/build = %+v, want latest successful run", got["ci/build"])
+	}
+}
+
 func TestForge_IsUpToDate(t *testing.T) {
 	srv, f := newTestForge(t)
 	repo := srv.Repo("org", "app")


### PR DESCRIPTION
Retries and concurrency cancellation can leave multiple check runs under one required-check context, allowing an older cancelled run to mask a newer successful result and keep eligible auto-merge pull requests out of the queue. Select the run with the newest GitHub check ID for each context, with a regression test covering a successful retry after cancellation