### PR TITLE
batch: commit landing atomically, detach checks from request context

### DIFF
--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -258,6 +258,18 @@ func (e *Engine) HandlePass(ctx context.Context, b *pg.Batch) error {
 	if err != nil {
 		return err
 	}
+
+	// Persist the transition before the best-effort forge work below: the
+	// target branch has already moved.
+	landed := b.CurrentIds
+	b.LandedIds = append(b.LandedIds, landed...)
+	b.CurrentIds = nil
+	build := popNext(b)
+	if err := e.Queue.SaveBatch(ctx, b, landed...); err != nil {
+		return err
+	}
+	slog.Info("batch landed", "batch", b.ID, "sha", sha, "prs", len(entries))
+
 	desc := fmt.Sprintf("Merged via batch #%d", b.ID)
 	var wg sync.WaitGroup
 	for i := range entries {
@@ -265,17 +277,11 @@ func (e *Engine) HandlePass(ctx context.Context, b *pg.Batch) error {
 		logutil.WarnIfErr(e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
 			State: pg.CheckStateSuccess, Description: desc, TargetURL: e.prURL(ent.PrNumber),
 		}), "set mq status failed", "pr", ent.PrNumber)
-		if _, err := e.Queue.Dequeue(ctx, e.RepoID, ent.PrNumber); err != nil {
-			slog.Warn("dequeue landed PR failed", "pr", ent.PrNumber, "err", err)
-		}
 		wg.Go(func() { e.ensureMergedOrClose(ctx, ent, sha, b.ID) })
 	}
 	wg.Wait()
 
-	b.LandedIds = append(b.LandedIds, b.CurrentIds...)
-	b.CurrentIds = nil
-	slog.Info("batch landed", "batch", b.ID, "sha", sha, "prs", len(entries))
-	return e.next(ctx, b)
+	return e.finish(ctx, b, build)
 }
 
 // HandleFail bisects: split current, push the second half, rebuild the first.
@@ -455,32 +461,47 @@ func (e *Engine) rebuild(ctx context.Context, b *pg.Batch) error {
 	return e.Build(ctx, b)
 }
 
-// next pops the pending stack and rebuilds, or finishes the batch.
-func (e *Engine) next(ctx context.Context, b *pg.Batch) error {
+// popNext pops the pending stack into current (forming) or marks the batch
+// done. Returns true when a build is needed.
+func popNext(b *pg.Batch) bool {
 	pending := loadPending(b.Pending)
 	if n := len(pending); n > 0 {
 		b.CurrentIds = pending[n-1]
 		b.Pending = pending[:n-1].bytes()
-		return e.rebuild(ctx, b)
+		b.State = pg.BatchStateForming
+		return true
 	}
-
 	// Root failed but every member eventually landed and nobody was ejected →
 	// flaky CI or a cross-PR interaction across halves.
 	b.Flaky = len(b.EjectedIds) == 0 && b.Builds > 1 &&
 		len(b.LandedIds) == len(b.MemberIds)
 	b.State = pg.BatchStateDone
 	b.CurrentIds = nil
-	if err := e.Queue.SaveBatch(ctx, b); err != nil {
-		return err
+	return false
+}
+
+// finish builds the popped slice or cleans up the finished batch. A forming
+// row is retried by FormAndBuild, so errors here are recoverable.
+func (e *Engine) finish(ctx context.Context, b *pg.Batch, build bool) error {
+	if build {
+		return e.Build(ctx, b)
 	}
 	logutil.WarnIfErr(e.Forge.DeleteBranch(ctx, e.Owner, e.Repo, b.BranchName.String), "delete batch branch failed", "branch", b.BranchName.String)
-
 	slog.Info("batch done", "batch", b.ID, "landed", len(b.LandedIds),
 		"ejected", len(b.EjectedIds), "builds", b.Builds, "flaky", b.Flaky)
 	if e.Advance != nil {
 		e.Advance()
 	}
 	return nil
+}
+
+// next pops the pending stack and rebuilds, or finishes the batch.
+func (e *Engine) next(ctx context.Context, b *pg.Batch) error {
+	build := popNext(b)
+	if err := e.Queue.SaveBatch(ctx, b); err != nil {
+		return err
+	}
+	return e.finish(ctx, b, build)
 }
 
 // eject removes a single member: status, cancel automerge, comment, dequeue.

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -268,6 +268,38 @@ func TestBisect_BothHalvesPass_Flaky(t *testing.T) {
 
 // TestHandleCheck_EvaluatesAndDispatches drives the engine via the public
 // monitor entry point so the lock + guard + save + evaluate path is covered.
+// Cancelling the caller's context mid-HandlePass must not lose the landing.
+func TestHandlePass_ContextCanceledAfterFastForward(t *testing.T) {
+	e, f, svc, ctx := setup(t, 10, 20)
+
+	b, err := e.FormAndBuild(ctx, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cctx, cancel := context.WithCancel(ctx)
+	f.GetPRFn = func(_ context.Context, _, _ string, n int64) (*forge.PR, error) {
+		cancel()
+		return &forge.PR{Number: n, State: "open"}, nil
+	}
+
+	if err := e.HandlePass(cctx, b); err != nil {
+		t.Fatalf("HandlePass: %v", err)
+	}
+	b, err = svc.GetBatch(ctx, b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.State != pg.BatchStateDone || len(b.LandedIds) != 2 || len(b.CurrentIds) != 0 {
+		t.Fatalf("batch not landed: %+v", b)
+	}
+	for _, n := range []int64{10, 20} {
+		if ent, _ := svc.GetEntry(ctx, e.RepoID, n); ent != nil {
+			t.Fatalf("PR #%d still queued", n)
+		}
+	}
+}
+
 func TestHandleCheck_EvaluatesAndDispatches(t *testing.T) {
 	e, f, svc, ctx := setup(t, 10, 20)
 	f.merged[10], f.merged[20] = true, true

--- a/internal/queue/batch.go
+++ b/internal/queue/batch.go
@@ -100,13 +100,26 @@ func nn(s []int64) []int64 {
 	return s
 }
 
-// SaveBatch persists the mutable fields of a batch row.
-func (s *Service) SaveBatch(ctx context.Context, b *pg.Batch) error {
+// SaveBatch persists the mutable fields of a batch row. Any removeEntries
+// are deleted from the queue in the same transaction.
+func (s *Service) SaveBatch(ctx context.Context, b *pg.Batch, removeEntries ...int64) error {
+	if len(removeEntries) == 0 {
+		return saveBatch(ctx, s.queries(), b)
+	}
+	return s.withTx(ctx, func(q *pg.Queries) error {
+		if err := q.DeleteEntriesByIDs(ctx, removeEntries); err != nil {
+			return fmt.Errorf("delete entries: %w", err)
+		}
+		return saveBatch(ctx, q, b)
+	})
+}
+
+func saveBatch(ctx context.Context, q *pg.Queries, b *pg.Batch) error {
 	pending := b.Pending
 	if len(pending) == 0 {
 		pending = []byte("[]")
 	}
-	saved, err := s.queries().SaveBatch(ctx, pg.SaveBatchParams{
+	saved, err := q.SaveBatch(ctx, pg.SaveBatchParams{
 		ID:               b.ID,
 		State:            b.State,
 		CurrentIds:       nn(b.CurrentIds),

--- a/internal/store/pg/query.sql
+++ b/internal/store/pg/query.sql
@@ -90,6 +90,10 @@ LIMIT $3;
 SELECT * FROM queue_entries
 WHERE id = ANY(@ids::bigint[]);
 
+-- name: DeleteEntriesByIDs :exec
+DELETE FROM queue_entries
+WHERE id = ANY(@ids::bigint[]);
+
 -- name: SetEntryActiveBatch :exec
 UPDATE queue_entries
 SET active_batch_id = @active_batch_id, state = 'testing',

--- a/internal/store/pg/query.sql.go
+++ b/internal/store/pg/query.sql.go
@@ -100,6 +100,16 @@ func (q *Queries) CreateBatch(ctx context.Context, arg CreateBatchParams) (Batch
 	return i, err
 }
 
+const deleteEntriesByIDs = `-- name: DeleteEntriesByIDs :exec
+DELETE FROM queue_entries
+WHERE id = ANY($1::bigint[])
+`
+
+func (q *Queries) DeleteEntriesByIDs(ctx context.Context, ids []int64) error {
+	_, err := q.db.Exec(ctx, deleteEntriesByIDs, ids)
+	return err
+}
+
 const dequeueAllByRepo = `-- name: DequeueAllByRepo :exec
 DELETE FROM queue_entries
 WHERE repo_id = $1
@@ -140,8 +150,7 @@ type EnqueuePRParams struct {
 }
 
 func (q *Queries) EnqueuePR(ctx context.Context, arg EnqueuePRParams) (QueueEntry, error) {
-	row := q.db.QueryRow(
-		ctx, enqueuePR,
+	row := q.db.QueryRow(ctx, enqueuePR,
 		arg.RepoID,
 		arg.PrNumber,
 		arg.PrHeadSha,
@@ -613,8 +622,7 @@ type SaveBatchParams struct {
 }
 
 func (q *Queries) SaveBatch(ctx context.Context, arg SaveBatchParams) (Batch, error) {
-	row := q.db.QueryRow(
-		ctx, saveBatch,
+	row := q.db.QueryRow(ctx, saveBatch,
 		arg.ID,
 		arg.State,
 		arg.CurrentIds,
@@ -665,8 +673,7 @@ type SaveCheckStatusParams struct {
 }
 
 func (q *Queries) SaveCheckStatus(ctx context.Context, arg SaveCheckStatusParams) error {
-	_, err := q.db.Exec(
-		ctx, saveCheckStatus,
+	_, err := q.db.Exec(ctx, saveCheckStatus,
 		arg.QueueEntryID,
 		arg.Context,
 		arg.State,
@@ -770,8 +777,7 @@ type UpdateEntryMergeBranchParams struct {
 }
 
 func (q *Queries) UpdateEntryMergeBranch(ctx context.Context, arg UpdateEntryMergeBranchParams) error {
-	_, err := q.db.Exec(
-		ctx, updateEntryMergeBranch,
+	_, err := q.db.Exec(ctx, updateEntryMergeBranch,
 		arg.RepoID,
 		arg.PrNumber,
 		arg.MergeBranchName,

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -105,6 +105,8 @@ func Handler(secret string, repos RepoLookup, queueSvc *queue.Service) http.Hand
 // Returning 200 even on internal errors avoids forge retries causing duplicate
 // processing.
 func routeCheck(ctx context.Context, rm *RepoMonitor, svc *queue.Service, sha, checkCtx string, c forge.Check) {
+	// The forge may close the request early; keep processing anyway.
+	ctx = context.WithoutCancel(ctx)
 	entry := findEntryForCommit(ctx, svc, rm.Deps.RepoID, sha)
 	if entry == nil {
 		return


### PR DESCRIPTION

A cancelled webhook context (or crash) between fast-forward and the
final SaveBatch left the batch in 'testing' with its entries gone,
blocking the queue until manual cleanup. Remove landed entries and save
the batch state in one transaction right after the fast-forward.
The forge calls afterwards are best-effort and retried via the forming
state.

Fixes #78
