### PR TITLE
batch: delete queue entries in the same transaction as the batch row

### DIFF
--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -200,7 +200,7 @@ func (e *Engine) Build(ctx context.Context, b *pg.Batch) error {
 	b.TestingStartedAt = pgtype.Timestamptz{Time: time.Now(), Valid: true}
 	first := b.Builds == 0
 	b.Builds++
-	if err := e.Queue.SaveBatch(ctx, b); err != nil {
+	if err := e.Queue.SaveBatch(ctx, b, b.EjectedIds...); err != nil {
 		return err
 	}
 
@@ -259,13 +259,12 @@ func (e *Engine) HandlePass(ctx context.Context, b *pg.Batch) error {
 		return err
 	}
 
-	// Persist the transition before the best-effort forge work below: the
-	// target branch has already moved.
+	// Persist before the best-effort forge work: the target already moved.
 	landed := b.CurrentIds
 	b.LandedIds = append(b.LandedIds, landed...)
 	b.CurrentIds = nil
 	build := popNext(b)
-	if err := e.Queue.SaveBatch(ctx, b, landed...); err != nil {
+	if err := e.Queue.SaveBatch(ctx, b, slices.Concat(landed, b.EjectedIds)...); err != nil {
 		return err
 	}
 	slog.Info("batch landed", "batch", b.ID, "sha", sha, "prs", len(entries))
@@ -363,7 +362,7 @@ func (e *Engine) OnMemberRemoved(ctx context.Context, targetBranch string, batch
 	b.Pending = loadPending(b.Pending).drop(id).bytes()
 	b.EjectedIds = append(b.EjectedIds, id)
 	if !wasCurrent {
-		return e.Queue.SaveBatch(ctx, b)
+		return e.Queue.SaveBatch(ctx, b, b.EjectedIds...)
 	}
 	if len(b.CurrentIds) == 0 {
 		return e.next(ctx, b)
@@ -455,14 +454,14 @@ func (e *Engine) stack(ctx context.Context, base string, heads []string, branch 
 // state guard) and then runs Build.
 func (e *Engine) rebuild(ctx context.Context, b *pg.Batch) error {
 	b.State = pg.BatchStateForming
-	if err := e.Queue.SaveBatch(ctx, b); err != nil {
+	if err := e.Queue.SaveBatch(ctx, b, b.EjectedIds...); err != nil {
 		return err
 	}
 	return e.Build(ctx, b)
 }
 
-// popNext pops the pending stack into current (forming) or marks the batch
-// done. Returns true when a build is needed.
+// popNext pops the pending stack into current or marks the batch done.
+// Returns true when a build is needed.
 func popNext(b *pg.Batch) bool {
 	pending := loadPending(b.Pending)
 	if n := len(pending); n > 0 {
@@ -480,8 +479,8 @@ func popNext(b *pg.Batch) bool {
 	return false
 }
 
-// finish builds the popped slice or cleans up the finished batch. A forming
-// row is retried by FormAndBuild, so errors here are recoverable.
+// finish builds the popped slice or cleans up the finished batch; forming
+// rows are retried by FormAndBuild.
 func (e *Engine) finish(ctx context.Context, b *pg.Batch, build bool) error {
 	if build {
 		return e.Build(ctx, b)
@@ -498,22 +497,20 @@ func (e *Engine) finish(ctx context.Context, b *pg.Batch, build bool) error {
 // next pops the pending stack and rebuilds, or finishes the batch.
 func (e *Engine) next(ctx context.Context, b *pg.Batch) error {
 	build := popNext(b)
-	if err := e.Queue.SaveBatch(ctx, b); err != nil {
+	if err := e.Queue.SaveBatch(ctx, b, b.EjectedIds...); err != nil {
 		return err
 	}
 	return e.finish(ctx, b, build)
 }
 
-// eject removes a single member: status, cancel automerge, comment, dequeue.
+// eject marks a single member for removal: status, cancel automerge, comment.
 func (e *Engine) eject(ctx context.Context, b *pg.Batch, ent *pg.QueueEntry, state pg.CheckState, statusDesc, comment string) {
 	logutil.WarnIfErr(e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
 		State: state, Description: statusDesc, TargetURL: e.prURL(ent.PrNumber),
 	}), "set mq status failed", "pr", ent.PrNumber)
 	logutil.WarnIfErr(e.Forge.CancelAutoMerge(ctx, e.Owner, e.Repo, ent.PrNumber), "cancel automerge failed", "pr", ent.PrNumber)
 	logutil.WarnIfErr(e.Forge.Comment(ctx, e.Owner, e.Repo, ent.PrNumber, comment), "post comment failed", "pr", ent.PrNumber)
-	if _, err := e.Queue.Dequeue(ctx, e.RepoID, ent.PrNumber); err != nil {
-		slog.Warn("dequeue ejected PR failed", "pr", ent.PrNumber, "err", err)
-	}
+	// The next SaveBatch deletes EjectedIds from the queue.
 	b.EjectedIds = append(b.EjectedIds, ent.ID)
 }
 

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -268,7 +268,7 @@ func TestBisect_BothHalvesPass_Flaky(t *testing.T) {
 
 // TestHandleCheck_EvaluatesAndDispatches drives the engine via the public
 // monitor entry point so the lock + guard + save + evaluate path is covered.
-// Cancelling the caller's context mid-HandlePass must not lose the landing.
+// HandlePass keeps the landing when the caller's context gets cancelled.
 func TestHandlePass_ContextCanceledAfterFastForward(t *testing.T) {
 	e, f, svc, ctx := setup(t, 10, 20)
 

--- a/internal/queue/batch.go
+++ b/internal/queue/batch.go
@@ -100,8 +100,7 @@ func nn(s []int64) []int64 {
 	return s
 }
 
-// SaveBatch persists the mutable fields of a batch row. Any removeEntries
-// are deleted from the queue in the same transaction.
+// SaveBatch persists the batch row
 func (s *Service) SaveBatch(ctx context.Context, b *pg.Batch, removeEntries ...int64) error {
 	if len(removeEntries) == 0 {
 		return saveBatch(ctx, s.queries(), b)


### PR DESCRIPTION

When the webhook context got cancelled (or the process crashed) between
fast-forward and the final SaveBatch, the batch stayed in 'testing'
while its entries were already dequeued. The queue then hung until
someone fixed the row by hand. Ejections had the same window through
their inline dequeue.

Delete landed and ejected entries together with the batch row save.
Forge calls happen after the commit and may fail. routeCheck now runs
on a context that outlives the webhook request.

Fixes #78
