### PR TITLE
Add label-triggered merges with GitHub stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ CI runs there. If all required checks pass, gitea-mq marks its own status
 times out, gitea-mq cancels automerge and posts a comment saying what went
 wrong.
 
+Alternatively, adding the merge label (default `merge-queue`, see
+`GITEA_MQ_MERGE_LABEL`) to a PR enqueues it without automerge. On GitHub this
+is the way to merge [stacked pull requests](https://gh.io/stacks), which have
+no auto-merge: label the topmost PR you want to merge, gitea-mq tests the
+whole stack against the stack's base branch and, on green, marks all stack
+heads as passed and performs the atomic stack merge itself. Stacked PRs
+without the label get a pending `gitea-mq` status hinting at this workflow.
+Removing the label removes the PR from the queue.
+
 Only one PR is tested at a time per target branch. PRs targeting different
 branches get independent queues. If the head-of-queue PR already contains the
 current target tip, the merge-branch run is skipped and the PR's own green CI
@@ -62,6 +71,7 @@ variables.
 | `GITEA_MQ_CHECK_TIMEOUT` | no | `1h` | Timeout for required checks |
 | `GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE` | no | `true` | Skip the merge-branch CI run when a PR is already rebased onto the target branch tip (its own green CI already covers the merged tree) |
 | `GITEA_MQ_REQUIRED_CHECKS` | no | - | Fallback required CI contexts when branch protection has none (comma-separated) |
+| `GITEA_MQ_MERGE_LABEL` | no | `merge-queue` | Label that enqueues a PR (stack-aware on GitHub); set to `none` to disable |
 | `GITEA_MQ_BATCH_MAX` | no | `1` | Max PRs tested together as one batch. `1` = batching off (legacy behaviour). `0` = everything currently queued |
 | `GITEA_MQ_BISECT_MAX_STEPS` | no | `0` | Cap on CI builds spent bisecting one batch. `0` = unlimited |
 | `GITEA_MQ_REFRESH_INTERVAL` | no | `10s` | Dashboard auto-refresh interval |

--- a/cmd/gitea-mq/main.go
+++ b/cmd/gitea-mq/main.go
@@ -125,6 +125,7 @@ func run() error {
 		IdlePollInterval:    cfg.IdlePollInterval,
 		CheckTimeout:        cfg.CheckTimeout,
 		FallbackChecks:      cfg.RequiredChecks,
+		MergeLabel:          cfg.MergeLabel,
 		SuccessTimeout:      5 * time.Minute,
 		SkipQueueIfUpToDate: cfg.SkipQueueIfUpToDate,
 		BatchMax:            cfg.BatchMax,

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -49,6 +49,7 @@ type Engine struct {
 	BisectMaxSteps int
 	CheckTimeout   time.Duration
 	FallbackChecks []string
+	MergeLabel     string
 
 	// MergedPoll controls ensureMergedOrClose. Defaults: 200ms × 50 = 10s.
 	MergedPollInterval time.Duration
@@ -508,7 +509,7 @@ func (e *Engine) eject(ctx context.Context, b *pg.Batch, ent *pg.QueueEntry, sta
 	logutil.WarnIfErr(e.Forge.SetMQStatus(ctx, e.Owner, e.Repo, ent.PrHeadSha, forge.MQStatus{
 		State: state, Description: statusDesc, TargetURL: e.prURL(ent.PrNumber),
 	}), "set mq status failed", "pr", ent.PrNumber)
-	logutil.WarnIfErr(e.Forge.CancelAutoMerge(ctx, e.Owner, e.Repo, ent.PrNumber), "cancel automerge failed", "pr", ent.PrNumber)
+	logutil.WarnIfErr(forge.CancelMergeIntent(ctx, e.Forge, e.Owner, e.Repo, ent.PrNumber, e.MergeLabel), "cancel merge intent failed", "pr", ent.PrNumber)
 	logutil.WarnIfErr(e.Forge.Comment(ctx, e.Owner, e.Repo, ent.PrNumber, comment), "post comment failed", "pr", ent.PrNumber)
 	// The next SaveBatch deletes EjectedIds from the queue.
 	b.EjectedIds = append(b.EjectedIds, ent.ID)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	IdlePollInterval    time.Duration
 	CheckTimeout        time.Duration
 	RequiredChecks      []string
+	MergeLabel          string
 	SkipQueueIfUpToDate bool
 	BatchMax            int
 	BisectMaxSteps      int
@@ -138,6 +139,11 @@ func Load() (*Config, error) {
 				cfg.RequiredChecks = append(cfg.RequiredChecks, c)
 			}
 		}
+	}
+
+	cfg.MergeLabel = envOrDefault("GITEA_MQ_MERGE_LABEL", "merge-queue")
+	if cfg.MergeLabel == "none" {
+		cfg.MergeLabel = ""
 	}
 
 	cfg.SkipQueueIfUpToDate, err = parseBool("GITEA_MQ_SKIP_QUEUE_IF_UP_TO_DATE", true)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -124,6 +124,72 @@ type PR struct {
 	BaseBranch       string
 	HTMLURL          string
 	AutoMergeEnabled bool
+	Labels           []string
+}
+
+// HasLabel reports whether the PR carries the given label (case-insensitive,
+// matching forge semantics).
+func (p *PR) HasLabel(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, l := range p.Labels {
+		if strings.EqualFold(l, name) {
+			return true
+		}
+	}
+	return false
+}
+
+type StackPR struct {
+	Number  int64
+	HeadSHA string
+	Merged  bool
+}
+
+// Stack is an ordered (bottom→top) chain of stacked PRs targeting BaseBranch.
+type Stack struct {
+	BaseBranch string
+	PRs        []StackPR
+}
+
+// MembersUpTo returns the members up to and including number, and whether
+// number is part of the stack.
+func (s *Stack) MembersUpTo(number int64) ([]StackPR, bool) {
+	for i, p := range s.PRs {
+		if p.Number == number {
+			return s.PRs[:i+1], true
+		}
+	}
+	return nil, false
+}
+
+// StackResolver is optionally implemented by forges with native stacked-PR
+// support (GitHub). ResolveStack returns nil (no error) when the PR is not
+// part of a stack or the feature is unavailable.
+type StackResolver interface {
+	ResolveStack(ctx context.Context, owner, name string, number int64) (*Stack, error)
+}
+
+// ResolveStack looks up the PR's stack when the forge supports stacks.
+func ResolveStack(ctx context.Context, f Forge, owner, name string, number int64) (*Stack, error) {
+	sr, ok := f.(StackResolver)
+	if !ok {
+		return nil, nil
+	}
+	return sr.ResolveStack(ctx, owner, name, number)
+}
+
+// CancelMergeIntent withdraws whatever signal put the PR into the queue:
+// forge-native automerge and, when configured, the merge label.
+func CancelMergeIntent(ctx context.Context, f Forge, owner, name string, number int64, mergeLabel string) error {
+	err := f.CancelAutoMerge(ctx, owner, name, number)
+	if mergeLabel != "" {
+		if lerr := f.RemoveLabel(ctx, owner, name, number, mergeLabel); lerr != nil && err == nil {
+			err = lerr
+		}
+	}
+	return err
 }
 
 // MQStatus is the lifecycle state reported by gitea-mq for a head SHA.
@@ -205,6 +271,12 @@ type Forge interface {
 	IsUpToDate(ctx context.Context, owner, name, base, headSHA string) (bool, error)
 
 	CancelAutoMerge(ctx context.Context, owner, name string, number int64) error
+	// RemoveLabel removes a label from a PR; a missing label is not an error.
+	RemoveLabel(ctx context.Context, owner, name string, number int64, label string) error
+	// MergePR merges the PR (on GitHub: the whole stack up to and including
+	// it, atomically). May complete asynchronously; callers observe the
+	// PR's merged state.
+	MergePR(ctx context.Context, owner, name string, number int64) error
 	Comment(ctx context.Context, owner, name string, number int64, body string) error
 
 	EnsureRepoSetup(ctx context.Context, owner, name string, cfg SetupConfig) error

--- a/internal/forge/mock.go
+++ b/internal/forge/mock.go
@@ -34,6 +34,9 @@ type MockForge struct {
 	ListBranchesFn      func(ctx context.Context, owner, name string) ([]string, error)
 	IsUpToDateFn        func(ctx context.Context, owner, name, base, headSHA string) (bool, error)
 	CancelAutoMergeFn   func(ctx context.Context, owner, name string, number int64) error
+	RemoveLabelFn       func(ctx context.Context, owner, name string, number int64, label string) error
+	MergePRFn           func(ctx context.Context, owner, name string, number int64) error
+	ResolveStackFn      func(ctx context.Context, owner, name string, number int64) (*Stack, error)
 	CommentFn           func(ctx context.Context, owner, name string, number int64, body string) error
 	EnsureRepoSetupFn   func(ctx context.Context, owner, name string, cfg SetupConfig) error
 	MergeIntoFn         func(ctx context.Context, owner, name, branch, headSHA string) (string, bool, error)
@@ -41,7 +44,34 @@ type MockForge struct {
 	ClosePRFn           func(ctx context.Context, owner, name string, number int64) error
 }
 
-var _ Forge = (*MockForge)(nil)
+var (
+	_ Forge         = (*MockForge)(nil)
+	_ StackResolver = (*MockForge)(nil)
+)
+
+func (m *MockForge) RemoveLabel(ctx context.Context, owner, name string, number int64, label string) error {
+	m.record("RemoveLabel", owner, name, number, label)
+	if m.RemoveLabelFn != nil {
+		return m.RemoveLabelFn(ctx, owner, name, number, label)
+	}
+	return nil
+}
+
+func (m *MockForge) MergePR(ctx context.Context, owner, name string, number int64) error {
+	m.record("MergePR", owner, name, number)
+	if m.MergePRFn != nil {
+		return m.MergePRFn(ctx, owner, name, number)
+	}
+	return nil
+}
+
+func (m *MockForge) ResolveStack(ctx context.Context, owner, name string, number int64) (*Stack, error) {
+	m.record("ResolveStack", owner, name, number)
+	if m.ResolveStackFn != nil {
+		return m.ResolveStackFn(ctx, owner, name, number)
+	}
+	return nil, nil
+}
 
 func (m *MockForge) record(method string, args ...any) {
 	m.mu.Lock()

--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -22,6 +22,13 @@ type PR struct {
 	Head      *PRRef     `json:"head"`
 	Base      *PRRef     `json:"base"`
 	HTMLURL   string     `json:"html_url"`
+	Labels    []*Label   `json:"labels"`
+}
+
+// Label represents an issue/PR label from the Gitea API (subset of fields).
+type Label struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 // PRRef holds a branch ref and its current SHA.
@@ -191,6 +198,14 @@ type Client interface {
 	// CancelAutoMerge cancels the scheduled automerge for a pull request.
 	// DELETE /repos/{owner}/{repo}/pulls/{index}/merge
 	CancelAutoMerge(ctx context.Context, owner, repo string, index int64) error
+
+	// MergePR merges a pull request into its base branch.
+	// POST /repos/{owner}/{repo}/pulls/{index}/merge
+	MergePR(ctx context.Context, owner, repo string, index int64) error
+
+	// RemoveIssueLabel removes a label (by id) from an issue or PR.
+	// DELETE /repos/{owner}/{repo}/issues/{index}/labels/{id}
+	RemoveIssueLabel(ctx context.Context, owner, repo string, index, labelID int64) error
 
 	// GetBranchProtection returns the branch protection rule for a branch.
 	// GET /repos/{owner}/{repo}/branch_protections/{name}

--- a/internal/gitea/forge.go
+++ b/internal/gitea/forge.go
@@ -106,6 +106,11 @@ func toForgePR(pr *PR, autoMerge bool) forge.PR {
 	if pr.Base != nil {
 		out.BaseBranch = pr.Base.Ref
 	}
+	for _, l := range pr.Labels {
+		if l != nil {
+			out.Labels = append(out.Labels, l.Name)
+		}
+	}
 	return out
 }
 
@@ -274,6 +279,25 @@ func (f *giteaForge) ListBranches(ctx context.Context, owner, name string) ([]st
 
 func (f *giteaForge) CancelAutoMerge(ctx context.Context, owner, name string, number int64) error {
 	return f.client.CancelAutoMerge(ctx, owner, name, number)
+}
+
+func (f *giteaForge) MergePR(ctx context.Context, owner, name string, number int64) error {
+	return f.client.MergePR(ctx, owner, name, number)
+}
+
+// RemoveLabel resolves the label name to its id (Gitea's delete endpoint is
+// id-based).
+func (f *giteaForge) RemoveLabel(ctx context.Context, owner, name string, number int64, label string) error {
+	pr, err := f.client.GetPR(ctx, owner, name, number)
+	if err != nil {
+		return err
+	}
+	for _, l := range pr.Labels {
+		if l != nil && strings.EqualFold(l.Name, label) {
+			return f.client.RemoveIssueLabel(ctx, owner, name, number, l.ID)
+		}
+	}
+	return nil
 }
 
 func (f *giteaForge) Comment(ctx context.Context, owner, name string, number int64, body string) error {

--- a/internal/gitea/http.go
+++ b/internal/gitea/http.go
@@ -581,6 +581,24 @@ func (c *HTTPClient) EditIssueState(ctx context.Context, owner, repo string, ind
 		fmt.Sprintf("edit issue #%d state in %s/%s", index, owner, repo))
 }
 
+// POST /repos/{owner}/{repo}/pulls/{index}/merge
+func (c *HTTPClient) MergePR(ctx context.Context, owner, repo string, index int64) error {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, index)
+	return c.doDiscard(ctx, http.MethodPost, path, map[string]string{"Do": "merge"},
+		fmt.Sprintf("merge PR #%d in %s/%s", index, owner, repo))
+}
+
+// DELETE /repos/{owner}/{repo}/issues/{index}/labels/{id}; 404 is success.
+func (c *HTTPClient) RemoveIssueLabel(ctx context.Context, owner, repo string, index, labelID int64) error {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%d", owner, repo, index, labelID)
+	err := c.doDiscard(ctx, http.MethodDelete, path, nil,
+		fmt.Sprintf("remove label %d from PR #%d in %s/%s", labelID, index, owner, repo))
+	if err != nil && IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // NotFastForwardError indicates a rejected non-fast-forward push.
 type NotFastForwardError struct {
 	Branch, SHA string

--- a/internal/gitea/mock.go
+++ b/internal/gitea/mock.go
@@ -29,6 +29,8 @@ type MockClient struct {
 	CreateCommitStatusFn      func(ctx context.Context, owner, repo, sha string, status CommitStatus) error
 	CreateCommentFn           func(ctx context.Context, owner, repo string, index int64, body string) error
 	CancelAutoMergeFn         func(ctx context.Context, owner, repo string, index int64) error
+	MergePRFn                 func(ctx context.Context, owner, repo string, index int64) error
+	RemoveIssueLabelFn        func(ctx context.Context, owner, repo string, index, labelID int64) error
 	GetBranchProtectionFn     func(ctx context.Context, owner, repo, branch string) (*BranchProtection, error)
 	ListBranchesFn            func(ctx context.Context, owner, repo string) ([]Branch, error)
 	CreateBranchFn            func(ctx context.Context, owner, repo, name, target string) error
@@ -69,6 +71,26 @@ func (m *MockClient) CallsTo(method string) []MockCall {
 	}
 
 	return result
+}
+
+func (m *MockClient) MergePR(ctx context.Context, owner, repo string, index int64) error {
+	m.record("MergePR", owner, repo, index)
+
+	if m.MergePRFn != nil {
+		return m.MergePRFn(ctx, owner, repo, index)
+	}
+
+	return nil
+}
+
+func (m *MockClient) RemoveIssueLabel(ctx context.Context, owner, repo string, index, labelID int64) error {
+	m.record("RemoveIssueLabel", owner, repo, index, labelID)
+
+	if m.RemoveIssueLabelFn != nil {
+		return m.RemoveIssueLabelFn(ctx, owner, repo, index, labelID)
+	}
+
+	return nil
 }
 
 // Reset clears all recorded calls.

--- a/internal/github/forge.go
+++ b/internal/github/forge.go
@@ -15,7 +15,10 @@ import (
 	"github.com/Mic92/gitea-mq/internal/forge"
 )
 
-var _ forge.Forge = (*githubForge)(nil)
+var (
+	_ forge.Forge         = (*githubForge)(nil)
+	_ forge.StackResolver = (*githubForge)(nil)
+)
 
 type githubForge struct {
 	app       *App
@@ -44,7 +47,12 @@ func (f *githubForge) BranchHTMLURL(owner, name, branch string) string {
 }
 
 func toForgePR(p *gh.PullRequest) forge.PR {
+	var labels []string
+	for _, l := range p.Labels {
+		labels = append(labels, l.GetName())
+	}
 	return forge.PR{
+		Labels:           labels,
 		Number:           int64(p.GetNumber()),
 		Title:            p.GetTitle(),
 		State:            p.GetState(),
@@ -395,6 +403,112 @@ func (f *githubForge) CancelAutoMerge(ctx context.Context, owner, name string, n
 			return nil
 		}
 		return fmt.Errorf("disablePullRequestAutoMerge: %s", msg)
+	}
+	return nil
+}
+
+func (f *githubForge) RemoveLabel(ctx context.Context, owner, name string, number int64, label string) error {
+	c, err := f.app.ClientForRepo(owner, name)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Issues.RemoveLabelForIssue(ctx, owner, name, int(number), label)
+	// Idempotent: the label may already be gone.
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	return err
+}
+
+func stackAPIPath(owner, name string) string {
+	return fmt.Sprintf("repos/%s/%s/stacks", owner, name)
+}
+
+type remoteStack struct {
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	PullRequests []struct {
+		Number   int     `json:"number"`
+		MergedAt *string `json:"merged_at"`
+		Head     struct {
+			Sha string `json:"sha"`
+		} `json:"head"`
+	} `json:"pull_requests"`
+}
+
+// ResolveStack returns nil when the PR is not stacked or the repo has
+// stacked PRs disabled (404).
+func (f *githubForge) ResolveStack(ctx context.Context, owner, name string, number int64) (*forge.Stack, error) {
+	c, err := f.app.ClientForRepo(owner, name)
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.NewRequest("GET", fmt.Sprintf("%s?pull_request=%d", stackAPIPath(owner, name), number), nil)
+	if err != nil {
+		return nil, err
+	}
+	var stacks []remoteStack
+	resp, err := c.Do(ctx, req, &stacks)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("resolve stack for PR #%d: %w", number, err)
+	}
+	if len(stacks) == 0 {
+		return nil, nil
+	}
+	s := &forge.Stack{BaseBranch: stacks[0].Base.Ref}
+	for _, p := range stacks[0].PullRequests {
+		s.PRs = append(s.PRs, forge.StackPR{
+			Number:  int64(p.Number),
+			HeadSHA: p.Head.Sha,
+			Merged:  p.MergedAt != nil && *p.MergedAt != "",
+		})
+	}
+	return s, nil
+}
+
+type asyncMergeResult struct {
+	Status  string `json:"status"` // pending, merged, enqueued, failed
+	Details struct {
+		Message string `json:"message"`
+	} `json:"details"`
+}
+
+// MergePR uses the async merge API (atomic for stacks). 409 means a merge
+// request is already in flight; 404 falls back to the classic endpoint.
+func (f *githubForge) MergePR(ctx context.Context, owner, name string, number int64) error {
+	c, err := f.app.ClientForRepo(owner, name)
+	if err != nil {
+		return err
+	}
+	body := map[string]string{"merge_action": "default"}
+	req, err := c.NewRequest("PUT", fmt.Sprintf("repos/%s/%s/pulls/%d/merge-async", owner, name, number), body)
+	if err != nil {
+		return err
+	}
+	var result asyncMergeResult
+	resp, err := c.Do(ctx, req, &result)
+	if err != nil {
+		var accepted *gh.AcceptedError
+		switch {
+		case errors.As(err, &accepted):
+			if jerr := json.Unmarshal(accepted.Raw, &result); jerr != nil {
+				return fmt.Errorf("async merge PR #%d: decode 202 body: %w", number, jerr)
+			}
+		case resp != nil && resp.StatusCode == http.StatusConflict:
+			return nil
+		case resp != nil && resp.StatusCode == http.StatusNotFound:
+			_, _, merr := c.PullRequests.Merge(ctx, owner, name, int(number), "", nil)
+			return merr
+		default:
+			return fmt.Errorf("async merge PR #%d: %w", number, err)
+		}
+	}
+	if result.Status == "failed" {
+		return fmt.Errorf("async merge PR #%d failed: %s", number, result.Details.Message)
 	}
 	return nil
 }

--- a/internal/github/ghfake/server.go
+++ b/internal/github/ghfake/server.go
@@ -34,6 +34,7 @@ type PR struct {
 	NodeID    string
 	AutoMerge bool
 	HTMLURL   string
+	Labels    []string
 }
 
 type CheckRun struct {
@@ -92,6 +93,20 @@ type Repo struct {
 	// ProtectionChecks[branch] feeds classic branch protection; absent
 	// branches answer 404 like unprotected ones.
 	ProtectionChecks map[string][]string
+
+	// Stacks feeds GET /stacks; nil answers 404 (feature disabled).
+	Stacks []Stack
+	// AsyncMerges records PUT /pulls/{n}/merge-async calls.
+	AsyncMerges []int64
+	// AsyncMergeStatus is the reported status (default "pending").
+	AsyncMergeStatus string
+	// AsyncMergeConflict makes merge-async return 409.
+	AsyncMergeConflict bool
+}
+
+type Stack struct {
+	BaseRef string
+	PRs     []int64 // bottom→top, resolved against Repo.PRs
 }
 
 // HookConfig mirrors the App-level webhook config (PATCH /app/hook/config).
@@ -255,6 +270,9 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE "+apiV3+"/repos/{o}/{r}/git/refs/{ref...}", s.hDeleteRef)
 	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/branches", s.hListBranches)
 	mux.HandleFunc("POST "+apiV3+"/repos/{o}/{r}/merges", s.hMerge)
+	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/stacks", s.hListStacks)
+	mux.HandleFunc("PUT "+apiV3+"/repos/{o}/{r}/pulls/{n}/merge-async", s.hMergeAsync)
+	mux.HandleFunc("DELETE "+apiV3+"/repos/{o}/{r}/issues/{n}/labels/{l}", s.hRemoveLabel)
 	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/compare/{basehead...}", s.hCompare)
 
 	// Rules / rulesets.
@@ -393,7 +411,16 @@ func prJSON(owner, name string, p *PR) map[string]any {
 		},
 		"base":       map[string]any{"ref": p.BaseRef},
 		"auto_merge": am,
+		"labels":     labelsJSON(p.Labels),
 	}
+}
+
+func labelsJSON(names []string) []map[string]any {
+	out := []map[string]any{}
+	for _, n := range names {
+		out = append(out, map[string]any{"name": n})
+	}
+	return out
 }
 
 func (s *Server) hListPRs(w http.ResponseWriter, r *http.Request) {
@@ -735,6 +762,91 @@ func (s *Server) hMerge(w http.ResponseWriter, r *http.Request) {
 	rp.Parents[mergeSHA] = []string{rp.Refs[body.Base], body.Head}
 	rp.Refs[body.Base] = mergeSHA
 	writeJSON(w, 201, map[string]any{"sha": mergeSHA})
+}
+
+func (s *Server) hListStacks(w http.ResponseWriter, r *http.Request) {
+	rp, ok := s.repoOr404(w, r)
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rp.Stacks == nil {
+		writeJSON(w, 404, map[string]any{"message": "Not Found"})
+		return
+	}
+	prFilter, _ := strconv.ParseInt(r.URL.Query().Get("pull_request"), 10, 64)
+	out := []map[string]any{}
+	for _, st := range rp.Stacks {
+		prs := []map[string]any{}
+		matched := prFilter == 0
+		for _, n := range st.PRs {
+			if n == prFilter {
+				matched = true
+			}
+			p := rp.PRs[n]
+			var mergedAt any
+			if p.Merged {
+				mergedAt = "2024-01-01T00:00:00Z"
+			}
+			prs = append(prs, map[string]any{
+				"number":    p.Number,
+				"merged_at": mergedAt,
+				"head":      map[string]any{"ref": p.HeadRef, "sha": p.HeadSHA},
+			})
+		}
+		if matched {
+			out = append(out, map[string]any{
+				"base":          map[string]any{"ref": st.BaseRef},
+				"pull_requests": prs,
+			})
+		}
+	}
+	writeJSON(w, 200, out)
+}
+
+func (s *Server) hMergeAsync(w http.ResponseWriter, r *http.Request) {
+	rp, ok := s.repoOr404(w, r)
+	if !ok {
+		return
+	}
+	n, _ := strconv.ParseInt(r.PathValue("n"), 10, 64)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rp.AsyncMergeConflict {
+		writeJSON(w, 409, map[string]any{"message": "a merge request already exists"})
+		return
+	}
+	rp.AsyncMerges = append(rp.AsyncMerges, n)
+	status := rp.AsyncMergeStatus
+	if status == "" {
+		status = "pending"
+	}
+	writeJSON(w, 202, map[string]any{"status": status, "details": map[string]any{"message": "boom"}})
+}
+
+func (s *Server) hRemoveLabel(w http.ResponseWriter, r *http.Request) {
+	rp, ok := s.repoOr404(w, r)
+	if !ok {
+		return
+	}
+	n, _ := strconv.ParseInt(r.PathValue("n"), 10, 64)
+	label := r.PathValue("l")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := rp.PRs[n]
+	if p == nil {
+		writeJSON(w, 404, map[string]any{"message": "Not Found"})
+		return
+	}
+	for i, l := range p.Labels {
+		if l == label {
+			p.Labels = append(p.Labels[:i], p.Labels[i+1:]...)
+			writeJSON(w, 200, []any{})
+			return
+		}
+	}
+	writeJSON(w, 404, map[string]any{"message": "Label does not exist"})
 }
 
 func (s *Server) hCompare(w http.ResponseWriter, r *http.Request) {

--- a/internal/github/stack_test.go
+++ b/internal/github/stack_test.go
@@ -1,0 +1,87 @@
+package github_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/github/ghfake"
+)
+
+func TestForge_ResolveStack(t *testing.T) {
+	srv, f := newTestForge(t)
+	srv.AddPR("org", "app", ghfake.PR{Number: 1, HeadRef: "b1", HeadSHA: "sha1", BaseRef: "main"})
+	srv.AddPR("org", "app", ghfake.PR{Number: 2, HeadRef: "b2", HeadSHA: "sha2", BaseRef: "b1"})
+	ctx := context.Background()
+
+	sr := f.(forge.StackResolver)
+
+	stack, err := sr.ResolveStack(ctx, "org", "app", 2)
+	if err != nil {
+		t.Fatalf("disabled stacks: %v", err)
+	}
+	if stack != nil {
+		t.Fatalf("expected nil stack when feature disabled, got %+v", stack)
+	}
+
+	srv.Repo("org", "app").Stacks = []ghfake.Stack{{BaseRef: "main", PRs: []int64{1, 2}}}
+
+	stack, err = sr.ResolveStack(ctx, "org", "app", 2)
+	if err != nil {
+		t.Fatalf("ResolveStack: %v", err)
+	}
+	if stack == nil || stack.BaseBranch != "main" || len(stack.PRs) != 2 {
+		t.Fatalf("stack = %+v", stack)
+	}
+	if stack.PRs[0].HeadSHA != "sha1" || stack.PRs[1].Number != 2 {
+		t.Errorf("members = %+v", stack.PRs)
+	}
+
+	members, ok := stack.MembersUpTo(1)
+	if !ok || len(members) != 1 || members[0].Number != 1 {
+		t.Errorf("MembersUpTo(1) = %+v, %v", members, ok)
+	}
+}
+
+func TestForge_MergePR_Async(t *testing.T) {
+	srv, f := newTestForge(t)
+	srv.AddPR("org", "app", ghfake.PR{Number: 5, HeadSHA: "sha5", BaseRef: "main"})
+	ctx := context.Background()
+	rp := srv.Repo("org", "app")
+
+	if err := f.MergePR(ctx, "org", "app", 5); err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+	if len(rp.AsyncMerges) != 1 || rp.AsyncMerges[0] != 5 {
+		t.Fatalf("AsyncMerges = %v", rp.AsyncMerges)
+	}
+
+	rp.AsyncMergeConflict = true
+	if err := f.MergePR(ctx, "org", "app", 5); err != nil {
+		t.Fatalf("409 must be treated as in-flight: %v", err)
+	}
+
+	rp.AsyncMergeConflict = false
+	rp.AsyncMergeStatus = "failed"
+	err := f.MergePR(ctx, "org", "app", 5)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected failure with server message, got %v", err)
+	}
+}
+
+func TestForge_RemoveLabel(t *testing.T) {
+	srv, f := newTestForge(t)
+	srv.AddPR("org", "app", ghfake.PR{Number: 3, HeadSHA: "sha3", BaseRef: "main", Labels: []string{"merge-queue"}})
+	ctx := context.Background()
+
+	if err := f.RemoveLabel(ctx, "org", "app", 3, "merge-queue"); err != nil {
+		t.Fatalf("RemoveLabel: %v", err)
+	}
+	if got := srv.Repo("org", "app").PRs[3].Labels; len(got) != 0 {
+		t.Fatalf("labels = %v", got)
+	}
+	if err := f.RemoveLabel(ctx, "org", "app", 3, "merge-queue"); err != nil {
+		t.Fatalf("second removal must be a no-op: %v", err)
+	}
+}

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -35,7 +35,7 @@ type StartTestingResult struct {
 // StartTesting creates a merge branch for the head-of-queue PR and
 // transitions it to the "testing" state. If the merge conflicts, the PR
 // is removed from the queue with automerge cancelled and a comment posted.
-func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner, repo string, repoID int64, entry *pg.QueueEntry, externalURL string) (*StartTestingResult, error) {
+func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner, repo string, repoID int64, entry *pg.QueueEntry, externalURL, mergeLabel string) (*StartTestingResult, error) {
 	branchName := BranchName(entry.PrNumber)
 	targetURL := forge.DashboardPRURL(externalURL, f.Kind(), owner, repo, entry.PrNumber)
 
@@ -43,12 +43,12 @@ func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner,
 	if conflict {
 		slog.Info("merge conflict", "pr", entry.PrNumber)
 
-		logutil.WarnIfErr(f.CancelAutoMerge(ctx, owner, repo, entry.PrNumber), "cancel automerge failed", "pr", entry.PrNumber)
+		logutil.WarnIfErr(forge.CancelMergeIntent(ctx, f, owner, repo, entry.PrNumber, mergeLabel), "cancel merge intent failed", "pr", entry.PrNumber)
 		logutil.WarnIfErr(f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
 			State: pg.CheckStateFailure, Description: "Merge conflict with target branch", TargetURL: targetURL,
 		}), "set mq status failed", "pr", entry.PrNumber)
 		logutil.WarnIfErr(f.Comment(ctx, owner, repo, entry.PrNumber,
-			"❌ Removed from merge queue: merge conflict with target branch. Please rebase and re-schedule automerge."),
+			"❌ Removed from merge queue: merge conflict with target branch. Please rebase and re-schedule the merge."),
 			"post comment failed", "pr", entry.PrNumber)
 
 		if _, err := svc.Dequeue(ctx, repoID, entry.PrNumber); err != nil {
@@ -61,7 +61,7 @@ func StartTesting(ctx context.Context, f forge.Forge, svc *queue.Service, owner,
 		// user and remove rather than retry silently.
 		slog.Error("merge branch creation failed", "pr", entry.PrNumber, "error", err)
 
-		logutil.WarnIfErr(f.CancelAutoMerge(ctx, owner, repo, entry.PrNumber), "cancel automerge failed", "pr", entry.PrNumber)
+		logutil.WarnIfErr(forge.CancelMergeIntent(ctx, f, owner, repo, entry.PrNumber, mergeLabel), "cancel merge intent failed", "pr", entry.PrNumber)
 		logutil.WarnIfErr(f.SetMQStatus(ctx, owner, repo, entry.PrHeadSha, forge.MQStatus{
 			State: pg.CheckStateError, Description: "Failed to create merge branch", TargetURL: targetURL,
 		}), "set mq status failed", "pr", entry.PrNumber)

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -43,7 +43,7 @@ func TestStartTesting_Success(t *testing.T) {
 	}
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
-	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com")
+	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestStartTesting_Conflict(t *testing.T) {
 	}
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
-	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com")
+	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestStartTesting_ClearsStaleStatuses(t *testing.T) {
 	}
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
-	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com")
+	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestStartTesting_NoStaleStatuses(t *testing.T) {
 	}
 	entry, _ := svc.GetEntry(ctx, repoID, 42)
 
-	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com")
+	result, err := merge.StartTesting(ctx, f, svc, "org", "app", repoID, entry, "https://mq.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -26,6 +26,7 @@ type Deps struct {
 	ExternalURL    string
 	CheckTimeout   time.Duration
 	FallbackChecks []string // from GITEA_MQ_REQUIRED_CHECKS
+	MergeLabel     string
 
 	// Batch, when non-nil, intercepts check results for entries that belong
 	// to a live batch. The single-PR success/failure handlers are skipped.
@@ -221,8 +222,8 @@ func removeFromQueue(ctx context.Context, deps *Deps, entry *pg.QueueEntry, stat
 		slog.Warn("failed to set status", "pr", entry.PrNumber, "error", err)
 	}
 
-	if err := deps.Forge.CancelAutoMerge(ctx, deps.Owner, deps.Repo, entry.PrNumber); err != nil {
-		slog.Warn("failed to cancel automerge", "pr", entry.PrNumber, "error", err)
+	if err := forge.CancelMergeIntent(ctx, deps.Forge, deps.Owner, deps.Repo, entry.PrNumber, deps.MergeLabel); err != nil {
+		slog.Warn("failed to cancel merge intent", "pr", entry.PrNumber, "error", err)
 	}
 
 	if err := deps.Forge.Comment(ctx, deps.Owner, deps.Repo, entry.PrNumber, comment); err != nil {

--- a/internal/poller/label_test.go
+++ b/internal/poller/label_test.go
@@ -1,0 +1,168 @@
+package poller_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/poller"
+	"github.com/Mic92/gitea-mq/internal/queue"
+	"github.com/Mic92/gitea-mq/internal/store/pg"
+	"github.com/Mic92/gitea-mq/internal/testutil"
+)
+
+func setupLabelTest(t *testing.T) (*poller.Deps, *forge.MockForge, *queue.Service, context.Context, int64) {
+	t.Helper()
+	svc, ctx, repoID := testutil.TestQueueService(t)
+	mock := &forge.MockForge{}
+	deps := &poller.Deps{
+		Forge:      mock,
+		Queue:      svc,
+		RepoID:     repoID,
+		Owner:      "org",
+		Repo:       "app",
+		MergeLabel: "merge-queue",
+	}
+	return deps, mock, svc, ctx, repoID
+}
+
+func TestLabeledPREnqueuedAndTested(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupLabelTest(t)
+	mock.ListOpenPRsFn = func(context.Context, string, string) ([]forge.PR, error) {
+		return []forge.PR{{Number: 7, State: "open", HeadSHA: "h7", BaseBranch: "main", Labels: []string{"merge-queue"}}}, nil
+	}
+	mock.CreateMergeBranchFn = func(context.Context, string, string, string, string, string) (string, bool, error) {
+		return "m7", false, nil
+	}
+
+	if _, err := poller.PollOnce(ctx, deps); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, err := svc.GetEntry(ctx, repoID, 7)
+	if err != nil || entry == nil {
+		t.Fatalf("entry = %v, err = %v", entry, err)
+	}
+	if entry.TargetBranch != "main" || entry.State != pg.EntryStateTesting {
+		t.Fatalf("entry = %+v", entry)
+	}
+}
+
+func TestLabeledStackPRUsesStackBase(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupLabelTest(t)
+	mock.ListOpenPRsFn = func(context.Context, string, string) ([]forge.PR, error) {
+		return []forge.PR{
+			{Number: 1, State: "open", HeadBranch: "b1", HeadSHA: "sha1", BaseBranch: "main"},
+			{Number: 2, State: "open", HeadBranch: "b2", HeadSHA: "sha2", BaseBranch: "b1", Labels: []string{"merge-queue"}},
+		}, nil
+	}
+	mock.ResolveStackFn = func(_ context.Context, _, _ string, number int64) (*forge.Stack, error) {
+		return &forge.Stack{BaseBranch: "main", PRs: []forge.StackPR{
+			{Number: 1, HeadSHA: "sha1"}, {Number: 2, HeadSHA: "sha2"},
+		}}, nil
+	}
+	mock.CreateMergeBranchFn = func(context.Context, string, string, string, string, string) (string, bool, error) {
+		return "m2", false, nil
+	}
+
+	if _, err := poller.PollOnce(ctx, deps); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, _ := svc.GetEntry(ctx, repoID, 2)
+	if entry == nil || entry.TargetBranch != "main" {
+		t.Fatalf("entry = %+v", entry)
+	}
+	if e, _ := svc.GetEntry(ctx, repoID, 1); e != nil {
+		t.Fatalf("unlabeled stack member must not be enqueued: %+v", e)
+	}
+}
+
+func TestLabelRemovalDequeues(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupLabelTest(t)
+	if _, err := svc.Enqueue(ctx, repoID, 7, "h7", "main"); err != nil {
+		t.Fatal(err)
+	}
+	mock.ListOpenPRsFn = func(context.Context, string, string) ([]forge.PR, error) {
+		return []forge.PR{{Number: 7, State: "open", HeadSHA: "h7", BaseBranch: "main"}}, nil
+	}
+
+	if _, err := poller.PollOnce(ctx, deps); err != nil {
+		t.Fatal(err)
+	}
+
+	if e, _ := svc.GetEntry(ctx, repoID, 7); e != nil {
+		t.Fatalf("entry should be dequeued: %+v", e)
+	}
+}
+
+func TestFinalizeLabeledStackMerge(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupLabelTest(t)
+	if _, err := svc.Enqueue(ctx, repoID, 2, "sha2", "main"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.UpdateState(ctx, repoID, 2, pg.EntryStateSuccess); err != nil {
+		t.Fatal(err)
+	}
+	mock.ListOpenPRsFn = func(context.Context, string, string) ([]forge.PR, error) {
+		return []forge.PR{
+			{Number: 1, State: "open", HeadBranch: "b1", HeadSHA: "sha1", BaseBranch: "main"},
+			{Number: 2, State: "open", HeadBranch: "b2", HeadSHA: "sha2", BaseBranch: "b1", Labels: []string{"merge-queue"}},
+		}, nil
+	}
+	mock.ResolveStackFn = func(context.Context, string, string, int64) (*forge.Stack, error) {
+		return &forge.Stack{BaseBranch: "main", PRs: []forge.StackPR{
+			{Number: 1, HeadSHA: "sha1"}, {Number: 2, HeadSHA: "sha2"},
+		}}, nil
+	}
+
+	if _, err := poller.PollOnce(ctx, deps); err != nil {
+		t.Fatal(err)
+	}
+
+	var memberGreen bool
+	for _, c := range mock.CallsTo("SetMQStatus") {
+		if c.Args[2] == "sha1" && c.Args[3].(forge.MQStatus).State == pg.CheckStateSuccess {
+			memberGreen = true
+		}
+	}
+	if !memberGreen {
+		t.Error("expected success status on stack member head sha1")
+	}
+	merges := mock.CallsTo("MergePR")
+	if len(merges) != 1 || merges[0].Args[2].(int64) != 2 {
+		t.Fatalf("MergePR calls = %+v", merges)
+	}
+}
+
+func TestStackHint(t *testing.T) {
+	deps, mock, _, ctx, _ := setupLabelTest(t)
+	mock.ListOpenPRsFn = func(context.Context, string, string) ([]forge.PR, error) {
+		return []forge.PR{
+			{Number: 1, State: "open", HeadBranch: "b1", HeadSHA: "sha1", BaseBranch: "main"},
+			{Number: 2, State: "open", HeadBranch: "b2", HeadSHA: "sha2", BaseBranch: "b1"},
+			{Number: 3, State: "open", HeadBranch: "b3", HeadSHA: "sha3", BaseBranch: "main"},
+		}, nil
+	}
+
+	for range 2 {
+		if _, err := poller.PollOnce(ctx, deps); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	hinted := map[string]int{}
+	for _, c := range mock.CallsTo("SetMQStatus") {
+		st := c.Args[3].(forge.MQStatus)
+		if strings.Contains(st.Description, "Stack detected") {
+			hinted[c.Args[2].(string)]++
+		}
+	}
+	if hinted["sha1"] != 1 || hinted["sha2"] != 1 {
+		t.Errorf("hints = %v, want exactly one per stack member", hinted)
+	}
+	if hinted["sha3"] != 0 {
+		t.Errorf("non-stack PR must not be hinted: %v", hinted)
+	}
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -32,6 +32,8 @@ type Deps struct {
 	ExternalURL string
 	// FallbackChecks gates enqueue when branch protection lists none.
 	FallbackChecks []string
+	// MergeLabel enqueues labeled PRs (stack-aware on GitHub); empty disables.
+	MergeLabel string
 	// SuccessTimeout is how long a PR may sit in "success" without merging
 	// before we assume the forge's auto-merge failed.
 	SuccessTimeout time.Duration
@@ -59,6 +61,9 @@ type Deps struct {
 	// TickDone, when non-nil, is signalled after each trigger/tick has been
 	// fully handled, letting tests sequence polls without sleeping.
 	TickDone chan<- struct{}
+
+	// hintedSHAs dedupes stack-hint statuses per head SHA.
+	hintedSHAs map[string]bool
 }
 
 func (d *Deps) now() time.Time {
@@ -77,11 +82,11 @@ type PollResult struct {
 }
 
 type removeOpts struct {
-	cancelAutomerge bool
-	comment         string
-	advance         bool
-	logMsg          string
-	logAttrs        []any
+	cancelIntent bool
+	comment      string
+	advance      bool
+	logMsg       string
+	logAttrs     []any
 }
 
 func removePR(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry, opts removeOpts) error {
@@ -90,8 +95,8 @@ func removePR(ctx context.Context, deps *Deps, result *PollResult, entry *pg.Que
 		return err
 	}
 
-	if opts.cancelAutomerge {
-		logutil.WarnIfErr(deps.Forge.CancelAutoMerge(ctx, deps.Owner, deps.Repo, entry.PrNumber), "cancel automerge failed", "pr", entry.PrNumber)
+	if opts.cancelIntent {
+		logutil.WarnIfErr(forge.CancelMergeIntent(ctx, deps.Forge, deps.Owner, deps.Repo, entry.PrNumber, deps.MergeLabel), "cancel merge intent failed", "pr", entry.PrNumber)
 	}
 	if opts.comment != "" {
 		logutil.WarnIfErr(deps.Forge.Comment(ctx, deps.Owner, deps.Repo, entry.PrNumber, opts.comment), "post comment failed", "pr", entry.PrNumber)
@@ -113,8 +118,8 @@ func removePR(ctx context.Context, deps *Deps, result *PollResult, entry *pg.Que
 
 // prCheckResult evaluates the PR's own head-commit checks against the
 // required checks. Reports CheckSuccess when no CI is configured at all.
-func prCheckResult(ctx context.Context, deps *Deps, pr *forge.PR) (monitor.CheckResult, error) {
-	requiredChecks, err := monitor.ResolveRequiredChecks(ctx, deps.Forge, deps.Owner, deps.Repo, pr.BaseBranch, deps.FallbackChecks)
+func prCheckResult(ctx context.Context, deps *Deps, pr *forge.PR, targetBranch string) (monitor.CheckResult, error) {
+	requiredChecks, err := monitor.ResolveRequiredChecks(ctx, deps.Forge, deps.Owner, deps.Repo, targetBranch, deps.FallbackChecks)
 	if err != nil {
 		return monitor.CheckWaiting, fmt.Errorf("resolve required checks for PR #%d: %w", pr.Number, err)
 	}
@@ -156,6 +161,8 @@ func PollOnce(ctx context.Context, deps *Deps) (*PollResult, error) {
 	}
 
 	enqueueAutoMergePRs(ctx, deps, result, openPRs)
+	enqueueLabeledPRs(ctx, deps, result, openPRs)
+	hintStackedPRs(ctx, deps, openPRs)
 	reconcileEntries(ctx, deps, result, openPRMap)
 	startQueuedHeads(ctx, deps, result)
 	pollMergeBranchChecks(ctx, deps, result)
@@ -174,6 +181,7 @@ func monitorDeps(deps *Deps) *monitor.Deps {
 		ExternalURL:    deps.ExternalURL,
 		CheckTimeout:   deps.CheckTimeout,
 		FallbackChecks: deps.FallbackChecks,
+		MergeLabel:     deps.MergeLabel,
 	}
 	if deps.Batch.Enabled() {
 		m.Batch = deps.Batch
@@ -282,33 +290,162 @@ func enqueueAutoMergePRs(ctx context.Context, deps *Deps, result *PollResult, op
 			continue
 		}
 
-		res, err := prCheckResult(ctx, deps, pr)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("check CI status for PR #%d: %w", pr.Number, err))
-			continue
+		enqueuePR(ctx, deps, result, pr, pr.BaseBranch, "automerge detection")
+	}
+}
+
+// enqueuePR adds a PR to the queue for targetBranch once its own CI is green.
+func enqueuePR(ctx context.Context, deps *Deps, result *PollResult, pr *forge.PR, targetBranch, source string) {
+	res, err := prCheckResult(ctx, deps, pr, targetBranch)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("check CI status for PR #%d: %w", pr.Number, err))
+		return
+	}
+	if res != monitor.CheckSuccess {
+		return
+	}
+
+	enqResult, err := deps.Queue.Enqueue(ctx, deps.RepoID, pr.Number, pr.HeadSHA, targetBranch)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("enqueue PR #%d: %w", pr.Number, err))
+		return
+	}
+
+	if enqResult.IsNew {
+		desc := fmt.Sprintf("Queued (position #%d)", enqResult.Position)
+		targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, pr.Number)
+		if err := deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, pr.HeadSHA, forge.MQStatus{
+			State: pg.CheckStatePending, Description: desc, TargetURL: targetURL,
+		}); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("set pending status for PR #%d: %w", pr.Number, err))
 		}
-		if res != monitor.CheckSuccess {
+
+		result.Enqueued = append(result.Enqueued, pr.Number)
+		slog.Info("enqueued PR from "+source, "pr", pr.Number, "position", enqResult.Position)
+	}
+}
+
+// enqueueLabeledPRs adds open PRs carrying the merge label. For stacked PRs
+// the queue target is the stack's base branch, not the parent PR's branch.
+func enqueueLabeledPRs(ctx context.Context, deps *Deps, result *PollResult, openPRs []forge.PR) {
+	if deps.MergeLabel == "" {
+		return
+	}
+	for i := range openPRs {
+		pr := &openPRs[i]
+		if !pr.HasLabel(deps.MergeLabel) {
 			continue
 		}
 
-		enqResult, err := deps.Queue.Enqueue(ctx, deps.RepoID, pr.Number, pr.HeadSHA, pr.BaseBranch)
+		existing, err := deps.Queue.GetEntry(ctx, deps.RepoID, pr.Number)
 		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("enqueue PR #%d: %w", pr.Number, err))
+			result.Errors = append(result.Errors, fmt.Errorf("check queue for PR #%d: %w", pr.Number, err))
+			continue
+		}
+		if existing != nil {
 			continue
 		}
 
-		if enqResult.IsNew {
-			desc := fmt.Sprintf("Queued (position #%d)", enqResult.Position)
-			targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, pr.Number)
-			if err := deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, pr.HeadSHA, forge.MQStatus{
-				State: pg.CheckStatePending, Description: desc, TargetURL: targetURL,
-			}); err != nil {
-				result.Errors = append(result.Errors, fmt.Errorf("set pending status for PR #%d: %w", pr.Number, err))
+		target, err := labeledTargetBranch(ctx, deps, pr)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("resolve stack for PR #%d: %w", pr.Number, err))
+			continue
+		}
+		enqueuePR(ctx, deps, result, pr, target, "merge label")
+	}
+}
+
+// labeledTargetBranch is the stack base branch for stacked PRs, else the PR's
+// own base branch.
+func labeledTargetBranch(ctx context.Context, deps *Deps, pr *forge.PR) (string, error) {
+	stack, err := forge.ResolveStack(ctx, deps.Forge, deps.Owner, deps.Repo, pr.Number)
+	if err != nil {
+		return "", err
+	}
+	if stack != nil {
+		if _, ok := stack.MembersUpTo(pr.Number); ok {
+			return stack.BaseBranch, nil
+		}
+	}
+	return pr.BaseBranch, nil
+}
+
+// hintStackedPRs surfaces the label workflow on stacked PRs, whose required
+// gitea-mq check would otherwise sit unset with no explanation: automerge is
+// not offered for stacks, so nothing would ever trigger the queue.
+func hintStackedPRs(ctx context.Context, deps *Deps, openPRs []forge.PR) {
+	if deps.MergeLabel == "" {
+		return
+	}
+	if _, ok := deps.Forge.(forge.StackResolver); !ok {
+		return
+	}
+
+	byHeadBranch := make(map[string]*forge.PR, len(openPRs))
+	for i := range openPRs {
+		byHeadBranch[openPRs[i].HeadBranch] = &openPRs[i]
+	}
+	stacked := make(map[int64]*forge.PR)
+	for i := range openPRs {
+		pr := &openPRs[i]
+		if parent, ok := byHeadBranch[pr.BaseBranch]; ok {
+			stacked[pr.Number] = pr
+			stacked[parent.Number] = parent
+		}
+	}
+
+	for _, pr := range stacked {
+		if pr.HasLabel(deps.MergeLabel) || deps.hintedSHAs[pr.HeadSHA] {
+			continue
+		}
+		entry, err := deps.Queue.GetEntry(ctx, deps.RepoID, pr.Number)
+		if err != nil || entry != nil {
+			continue
+		}
+		targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, pr.Number)
+		if err := deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, pr.HeadSHA, forge.MQStatus{
+			State:       pg.CheckStatePending,
+			Description: fmt.Sprintf("Stack detected — add the '%s' label to the topmost PR you want to merge", deps.MergeLabel),
+			TargetURL:   targetURL,
+		}); err != nil {
+			slog.Warn("set stack hint status failed", "pr", pr.Number, "error", err)
+			continue
+		}
+		if deps.hintedSHAs == nil {
+			deps.hintedSHAs = make(map[string]bool)
+		}
+		deps.hintedSHAs[pr.HeadSHA] = true
+	}
+}
+
+// finalizeLabeledMerge completes label-triggered entries that passed the
+// queue: the forge has no automerge armed for them, so gitea-mq flips the
+// remaining stack heads green and performs the (stack-aware) merge itself.
+func finalizeLabeledMerge(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry, pr *forge.PR) {
+	if deps.MergeLabel == "" || entry.State != pg.EntryStateSuccess || pr == nil || pr.Merged || !pr.HasLabel(deps.MergeLabel) {
+		return
+	}
+
+	stack, err := forge.ResolveStack(ctx, deps.Forge, deps.Owner, deps.Repo, entry.PrNumber)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("resolve stack for PR #%d: %w", entry.PrNumber, err))
+		return
+	}
+	if stack != nil {
+		members, _ := stack.MembersUpTo(entry.PrNumber)
+		targetURL := forge.DashboardPRURL(deps.ExternalURL, deps.Forge.Kind(), deps.Owner, deps.Repo, entry.PrNumber)
+		for _, m := range members {
+			if m.Merged || m.HeadSHA == entry.PrHeadSha {
+				continue
 			}
-
-			result.Enqueued = append(result.Enqueued, pr.Number)
-			slog.Info("enqueued PR from automerge detection", "pr", pr.Number, "position", enqResult.Position)
+			logutil.WarnIfErr(deps.Forge.SetMQStatus(ctx, deps.Owner, deps.Repo, m.HeadSHA, forge.MQStatus{
+				State: pg.CheckStateSuccess, Description: "Merge queue passed (stack)", TargetURL: targetURL,
+			}), "set stack member status failed", "pr", m.Number)
 		}
+	}
+
+	if err := deps.Forge.MergePR(ctx, deps.Owner, deps.Repo, entry.PrNumber); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("merge labeled PR #%d: %w", entry.PrNumber, err))
 	}
 }
 
@@ -333,6 +470,14 @@ func reconcileEntries(ctx context.Context, deps *Deps, result *PollResult, openP
 			pr = fullPR
 		}
 
+		labeled := deps.MergeLabel != "" && pr.HasLabel(deps.MergeLabel)
+		retargeted := pr.BaseBranch != "" && pr.BaseBranch != entry.TargetBranch
+		if retargeted && labeled {
+			if target, err := labeledTargetBranch(ctx, deps, pr); err == nil && target == entry.TargetBranch {
+				retargeted = false
+			}
+		}
+
 		checks := []struct {
 			when  bool
 			label string
@@ -349,29 +494,29 @@ func reconcileEntries(ctx context.Context, deps *Deps, result *PollResult, openP
 				opts:  removeOpts{logMsg: "removed closed PR from queue"},
 			},
 			{
-				when:  pr.BaseBranch != "" && pr.BaseBranch != entry.TargetBranch,
+				when:  retargeted,
 				label: "retargeted",
 				opts: removeOpts{
-					cancelAutomerge: true,
-					comment:         fmt.Sprintf("⚠️ Removed from merge queue: target branch changed from `%s` to `%s`. Please re-schedule automerge.", entry.TargetBranch, pr.BaseBranch),
-					logMsg:          "removed retargeted PR from queue",
-					logAttrs:        []any{"old_branch", entry.TargetBranch, "new_branch", pr.BaseBranch},
+					cancelIntent: true,
+					comment:      fmt.Sprintf("⚠️ Removed from merge queue: target branch changed from `%s` to `%s`. Please re-schedule the merge.", entry.TargetBranch, pr.BaseBranch),
+					logMsg:       "removed retargeted PR from queue",
+					logAttrs:     []any{"old_branch", entry.TargetBranch, "new_branch", pr.BaseBranch},
 				},
 			},
 			{
 				when:  pr.HeadSHA != "" && pr.HeadSHA != entry.PrHeadSha,
 				label: "pushed",
 				opts: removeOpts{
-					cancelAutomerge: true,
-					comment:         "⚠️ Removed from merge queue: new commits were pushed. Please re-schedule automerge.",
-					advance:         true,
-					logMsg:          "removed PR due to new push",
+					cancelIntent: true,
+					comment:      "⚠️ Removed from merge queue: new commits were pushed. Please re-schedule the merge.",
+					advance:      true,
+					logMsg:       "removed PR due to new push",
 				},
 			},
 			{
-				when:  !pr.AutoMergeEnabled,
+				when:  !pr.AutoMergeEnabled && !labeled,
 				label: "cancelled",
-				opts:  removeOpts{logMsg: "removed PR due to automerge cancellation"},
+				opts:  removeOpts{logMsg: "removed PR due to merge intent cancellation"},
 			},
 		}
 
@@ -394,6 +539,7 @@ func reconcileEntries(ctx context.Context, deps *Deps, result *PollResult, openP
 			}
 			continue
 		}
+		finalizeLabeledMerge(ctx, deps, result, &entry, pr)
 		handleSuccessTimeout(ctx, deps, result, &entry, pr)
 		handleTestingTimeout(ctx, deps, result, &entry)
 	}
@@ -410,7 +556,7 @@ func handleSuccessTimeout(ctx context.Context, deps *Deps, result *PollResult, e
 	}
 
 	if pr != nil && !timedOut(deps.now(), entry.CompletedAt, deps.CheckTimeout) {
-		res, err := prCheckResult(ctx, deps, pr)
+		res, err := prCheckResult(ctx, deps, pr, pr.BaseBranch)
 		if err != nil {
 			slog.Warn("success timeout: could not evaluate PR checks", "pr", entry.PrNumber, "error", err)
 		} else if res == monitor.CheckWaiting {
@@ -420,9 +566,9 @@ func handleSuccessTimeout(ctx context.Context, deps *Deps, result *PollResult, e
 	}
 
 	removeTimedOut(ctx, deps, result, entry, timedOutRemoval{
-		statusDescription: "Automerge did not complete in time",
-		errorMessage:      "automerge did not complete in time",
-		comment:           "⚠️ Removed from merge queue: PR was marked as ready to merge but Gitea did not merge it in time. This may indicate a branch protection issue.",
+		statusDescription: "Merge did not complete in time",
+		errorMessage:      "merge did not complete in time",
+		comment:           "⚠️ Removed from merge queue: PR was marked as ready to merge but the forge did not merge it in time. This may indicate a branch protection issue.",
 		logMsg:            "removed PR due to success-but-not-merged timeout",
 	})
 }
@@ -474,10 +620,10 @@ func removeTimedOut(ctx context.Context, deps *Deps, result *PollResult, entry *
 	logutil.WarnIfErr(deps.Queue.SetError(ctx, deps.RepoID, entry.PrNumber, opts.errorMessage), "set queue error failed", "pr", entry.PrNumber)
 
 	if err := removePR(ctx, deps, result, entry, removeOpts{
-		cancelAutomerge: true,
-		comment:         opts.comment,
-		advance:         true,
-		logMsg:          opts.logMsg,
+		cancelIntent: true,
+		comment:      opts.comment,
+		advance:      true,
+		logMsg:       opts.logMsg,
 	}); err != nil {
 		result.Errors = append(result.Errors, fmt.Errorf("dequeue timed-out PR #%d: %w", entry.PrNumber, err))
 	}
@@ -519,7 +665,7 @@ func startQueuedHeads(ctx context.Context, deps *Deps, result *PollResult) {
 			continue
 		}
 
-		startResult, err := merge.StartTesting(ctx, deps.Forge, deps.Queue, deps.Owner, deps.Repo, deps.RepoID, head, deps.ExternalURL)
+		startResult, err := merge.StartTesting(ctx, deps.Forge, deps.Queue, deps.Owner, deps.Repo, deps.RepoID, head, deps.ExternalURL, deps.MergeLabel)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("start testing for PR #%d: %w", head.PrNumber, err))
 			continue

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -37,6 +37,7 @@ type Deps struct {
 	IdlePollInterval    time.Duration
 	CheckTimeout        time.Duration
 	FallbackChecks      []string
+	MergeLabel          string
 	SuccessTimeout      time.Duration
 	SkipQueueIfUpToDate bool
 	BatchMax            int
@@ -118,6 +119,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 			BisectMaxSteps: r.deps.BisectMaxSteps,
 			CheckTimeout:   r.deps.CheckTimeout,
 			FallbackChecks: r.deps.FallbackChecks,
+			MergeLabel:     r.deps.MergeLabel,
 			Advance:        triggerPoll,
 		}
 	}
@@ -144,6 +146,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		ExternalURL:    r.deps.ExternalURL,
 		CheckTimeout:   r.deps.CheckTimeout,
 		FallbackChecks: r.deps.FallbackChecks,
+		MergeLabel:     r.deps.MergeLabel,
 	}
 	if batchEngine != nil {
 		monDeps.Batch = batchEngine
@@ -168,6 +171,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 		Trigger:             trigger,
 		ExternalURL:         r.deps.ExternalURL,
 		FallbackChecks:      r.deps.FallbackChecks,
+		MergeLabel:          r.deps.MergeLabel,
 		SuccessTimeout:      r.deps.SuccessTimeout,
 		CheckTimeout:        r.deps.CheckTimeout,
 		SkipQueueIfUpToDate: r.deps.SkipQueueIfUpToDate,

--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -22,6 +22,8 @@ var prTriggerActions = map[string]bool{
 	"reopened":            true,
 	"synchronize":         true,
 	"edited":              true, // base-branch retarget arrives as edited
+	"labeled":             true,
+	"unlabeled":           true,
 }
 
 // GithubHandler validates X-Hub-Signature-256, dispatches by X-GitHub-Event,

--- a/internal/webhook/github_test.go
+++ b/internal/webhook/github_test.go
@@ -40,7 +40,9 @@ func TestGithubHandler_PRTriggersPoll(t *testing.T) {
 		{"auto_merge_disabled", 1},
 		{"closed", 1},
 		{"synchronize", 1},
-		{"labeled", 0}, // irrelevant action must not poke the poller
+		{"labeled", 1},
+		{"unlabeled", 1},
+		{"assigned", 0}, // irrelevant action must not poke the poller
 	} {
 		polled = 0
 		body := `{"action":"` + tc.action + `","pull_request":{"number":1},"repository":{"name":"app","owner":{"login":"org"}}}`

--- a/nix/golangci-lint.nix
+++ b/nix/golangci-lint.nix
@@ -9,7 +9,7 @@ gitea-mq.overrideAttrs (old: {
   env.CGO_ENABLED = "0";
   buildPhase = ''
     HOME=$TMPDIR
-    golangci-lint run
+    GOMAXPROCS=$NIX_BUILD_CORES golangci-lint run --concurrency $NIX_BUILD_CORES
   '';
   installPhase = ''
     touch $out


### PR DESCRIPTION

GitHub's stacked PRs merge atomically server-side and have no auto-merge,
so gitea-mq's required check permanently blocked stack merges.

Add a merge label (GITEA_MQ_MERGE_LABEL, default merge-queue) as an
alternative enqueue signal. Labeled stack PRs are tested against the
stack's base branch; on green gitea-mq marks all stack heads passed and
merges the stack itself via the async merge API. Unlabeled stack PRs get
a status hinting at the label; removing the label dequeues.
