### PR TITLE
github: handle pre-existing rulesets that block fast-forward

### DIFF
--- a/internal/github/forge.go
+++ b/internal/github/forge.go
@@ -291,10 +291,10 @@ func (f *githubForge) FastForward(ctx context.Context, owner, name, branch, sha 
 			return forge.ErrNotFastForward
 		}
 		// Ruleset / branch-protection rejections come back as 422 or 403
-		// with assorted phrasings.
+		// with assorted phrasings, e.g. "Repository rule violations found".
 		if resp != nil && (resp.StatusCode == http.StatusForbidden ||
 			(resp.StatusCode == http.StatusUnprocessableEntity &&
-				(strings.Contains(msg, "protected branch") || strings.Contains(msg, "ruleset")))) {
+				(strings.Contains(msg, "protected branch") || strings.Contains(msg, "rule")))) {
 			return &forge.PushDeniedError{Branch: branch, Message: ghErr.Message}
 		}
 	}

--- a/internal/github/ghfake/server.go
+++ b/internal/github/ghfake/server.go
@@ -48,12 +48,20 @@ type CheckRun struct {
 }
 
 type Ruleset struct {
-	ID          int64           `json:"id"`
-	Name        string          `json:"name"`
-	Target      string          `json:"target"`
-	Enforcement string          `json:"enforcement"`
-	Conditions  json.RawMessage `json:"conditions,omitempty"`
-	Rules       []RulesetRule   `json:"rules"`
+	ID           int64           `json:"id"`
+	Name         string          `json:"name"`
+	Target       string          `json:"target"`
+	SourceType   string          `json:"source_type"`
+	Enforcement  string          `json:"enforcement"`
+	BypassActors []BypassActor   `json:"bypass_actors"`
+	Conditions   json.RawMessage `json:"conditions,omitempty"`
+	Rules        []RulesetRule   `json:"rules"`
+}
+
+type BypassActor struct {
+	ActorID    int64  `json:"actor_id"`
+	ActorType  string `json:"actor_type"`
+	BypassMode string `json:"bypass_mode"`
 }
 
 type RulesetRule struct {
@@ -82,7 +90,7 @@ type Repo struct {
 	Settings map[string]any
 
 	// ProtectedRefs[branch]=true makes a non-force PATCH on that ref return
-	// 403, simulating a ruleset/branch-protection rejection.
+	// 422 with GitHub's actual ruleset rejection message.
 	ProtectedRefs map[string]bool
 
 	// RequiredChecks[branch] feeds /rules/branches/{b} as a synthetic
@@ -280,6 +288,8 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/branches/{b}/protection/required_status_checks", s.hProtectionChecks)
 	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/rulesets", s.hListRulesets)
 	mux.HandleFunc("POST "+apiV3+"/repos/{o}/{r}/rulesets", s.hCreateRuleset)
+	mux.HandleFunc("GET "+apiV3+"/repos/{o}/{r}/rulesets/{id}", s.hGetRuleset)
+	mux.HandleFunc("PUT "+apiV3+"/repos/{o}/{r}/rulesets/{id}", s.hUpdateRuleset)
 
 	// GraphQL.
 	mux.HandleFunc("POST /api/graphql", s.hGraphQL)
@@ -681,7 +691,7 @@ func (s *Server) hUpdateRef(w http.ResponseWriter, r *http.Request) {
 	if !body.Force {
 		if rp.ProtectedRefs[branch] {
 			s.mu.Unlock()
-			writeJSON(w, 403, map[string]any{"message": "Changes must be made through a pull request. (protected branch)"})
+			writeJSON(w, 422, map[string]any{"message": "Repository rule violations found\n\nChanges must be made through a pull request.\n\n"})
 			return
 		}
 		if !rp.isAncestor(old, body.SHA) {
@@ -923,10 +933,57 @@ func (s *Server) hCreateRuleset(w http.ResponseWriter, r *http.Request) {
 	var rs Ruleset
 	_ = json.NewDecoder(r.Body).Decode(&rs)
 	rs.ID = s.nextID()
+	if rs.SourceType == "" {
+		rs.SourceType = "Repository"
+	}
 	s.mu.Lock()
 	rp.Rulesets = append(rp.Rulesets, &rs)
 	s.mu.Unlock()
 	writeJSON(w, 201, rs)
+}
+
+func (s *Server) ruleset(rp *Repo, r *http.Request) *Ruleset {
+	id, _ := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	for _, rs := range rp.Rulesets {
+		if rs.ID == id {
+			return rs
+		}
+	}
+	return nil
+}
+
+func (s *Server) hGetRuleset(w http.ResponseWriter, r *http.Request) {
+	rp, ok := s.repoOr404(w, r)
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rs := s.ruleset(rp, r)
+	if rs == nil {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, 200, rs)
+}
+
+// Org-sourced rulesets are visible on the repo but only editable at org level.
+func (s *Server) hUpdateRuleset(w http.ResponseWriter, r *http.Request) {
+	rp, ok := s.repoOr404(w, r)
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rs := s.ruleset(rp, r)
+	if rs == nil || rs.SourceType != "Repository" {
+		http.NotFound(w, r)
+		return
+	}
+	id := rs.ID
+	_ = json.NewDecoder(r.Body).Decode(rs)
+	rs.ID = id
+	writeJSON(w, 200, rs)
 }
 
 // --- GraphQL: only disablePullRequestAutoMerge ---

--- a/internal/github/setup.go
+++ b/internal/github/setup.go
@@ -40,10 +40,25 @@ func (f *githubForge) EnsureRepoSetup(ctx context.Context, owner, name string, _
 			"repo", owner+"/"+name, "err", err)
 		return nil
 	}
+	// The App must bypass its own gate to manage merge branches and to let
+	// GitHub fast-forward when it reports success.
+	self := &gh.BypassActor{
+		ActorID:    gh.Ptr(f.app.AppID()),
+		ActorType:  gh.Ptr(gh.BypassActorTypeIntegration),
+		BypassMode: gh.Ptr(gh.BypassModeAlways),
+	}
+	haveMQ := false
 	for _, rs := range rss {
 		if rs.Name == forge.MQContext {
-			return nil
+			haveMQ = true
+			continue
 		}
+		if err := f.ensureBypass(ctx, c, owner, name, rs, self); err != nil {
+			return err
+		}
+	}
+	if haveMQ {
+		return nil
 	}
 
 	_, resp, err = c.Repositories.CreateRuleset(ctx, owner, name, gh.RepositoryRuleset{
@@ -51,13 +66,7 @@ func (f *githubForge) EnsureRepoSetup(ctx context.Context, owner, name string, _
 		Target:      gh.Ptr(gh.RulesetTargetBranch),
 		Enforcement: gh.RulesetEnforcementActive,
 		BypassActors: []*gh.BypassActor{
-			// The App must bypass its own gate to manage merge branches and
-			// to let GitHub fast-forward when it reports success.
-			{
-				ActorID:    gh.Ptr(f.app.AppID()),
-				ActorType:  gh.Ptr(gh.BypassActorTypeIntegration),
-				BypassMode: gh.Ptr(gh.BypassModeAlways),
-			},
+			self,
 			// Repo admins keep an escape hatch for hotfixes.
 			{
 				ActorID:    gh.Ptr(repoAdminRoleID),
@@ -93,6 +102,41 @@ func (f *githubForge) EnsureRepoSetup(ctx context.Context, owner, name string, _
 		slog.Warn("github: cannot create ruleset (App lacks Administration permission)",
 			"repo", owner+"/"+name, "err", err)
 	}
+	return nil
+}
+
+// ensureBypass adds the App as bypass actor to a pre-existing branch ruleset
+// (e.g. "require pull request") that would otherwise reject the queue's
+// fast-forward with "Repository rule violations found".
+func (f *githubForge) ensureBypass(ctx context.Context, c *gh.Client, owner, name string, summary *gh.RepositoryRuleset, self *gh.BypassActor) error {
+	if summary.Target == nil || *summary.Target != gh.RulesetTargetBranch {
+		return nil
+	}
+	// The list endpoint omits bypass_actors and rules.
+	rs, _, err := c.Repositories.GetRuleset(ctx, owner, name, summary.GetID(), false)
+	if err != nil {
+		return err
+	}
+	for _, b := range rs.BypassActors {
+		if b.ActorType != nil && *b.ActorType == gh.BypassActorTypeIntegration && b.GetActorID() == self.GetActorID() {
+			return nil
+		}
+	}
+	if rs.SourceType == nil || *rs.SourceType != gh.RulesetSourceTypeRepository {
+		slog.Warn("github: org-level ruleset lacks gitea-mq bypass; fast-forwards to the default branch may be rejected",
+			"repo", owner+"/"+name, "ruleset", rs.Name, "source", rs.Source)
+		return nil
+	}
+	rs.BypassActors = append(rs.BypassActors, self)
+	if _, resp, err := c.Repositories.UpdateRuleset(ctx, owner, name, rs.GetID(), *rs); err != nil {
+		if !isForbidden(resp) {
+			return err
+		}
+		slog.Warn("github: cannot add gitea-mq bypass to ruleset",
+			"repo", owner+"/"+name, "ruleset", rs.Name, "err", err)
+		return nil
+	}
+	slog.Info("github: added gitea-mq as ruleset bypass actor", "repo", owner+"/"+name, "ruleset", rs.Name)
 	return nil
 }
 

--- a/internal/github/setup_test.go
+++ b/internal/github/setup_test.go
@@ -6,7 +6,47 @@ import (
 	"testing"
 
 	"github.com/Mic92/gitea-mq/internal/forge"
+	"github.com/Mic92/gitea-mq/internal/github/ghfake"
 )
+
+// A pre-existing "require pull request" ruleset rejects the queue's
+// fast-forward unless the App is a bypass actor there too.
+func TestForge_EnsureRepoSetup_bypassesExistingRulesets(t *testing.T) {
+	srv, f := newTestForge(t)
+	ctx := context.Background()
+	repo := srv.Repo("org", "app")
+	repo.Rulesets = []*ghfake.Ruleset{
+		{
+			ID: 10, Name: "default", Target: "branch", SourceType: "Repository", Enforcement: "active",
+			Rules: []ghfake.RulesetRule{{Type: "pull_request"}},
+		},
+		{
+			ID: 11, Name: "has-it", Target: "branch", SourceType: "Repository", Enforcement: "active",
+			BypassActors: []ghfake.BypassActor{{ActorID: 1, ActorType: "Integration", BypassMode: "always"}},
+		},
+		{ID: 12, Name: "tags", Target: "tag", SourceType: "Repository", Enforcement: "active"},
+		{ID: 13, Name: "org", Target: "branch", SourceType: "Organization", Enforcement: "active"},
+	}
+
+	for range 2 {
+		if err := f.EnsureRepoSetup(ctx, "org", "app", forge.SetupConfig{}); err != nil {
+			t.Fatalf("EnsureRepoSetup: %v", err)
+		}
+	}
+
+	want := map[string]int{"default": 1, "has-it": 1, "tags": 0, "org": 0, forge.MQContext: 2}
+	for _, rs := range repo.Rulesets {
+		if got := len(rs.BypassActors); got != want[rs.Name] {
+			t.Errorf("ruleset %q: %d bypass actors, want %d: %+v", rs.Name, got, want[rs.Name], rs.BypassActors)
+		}
+	}
+	if repo.Rulesets[0].BypassActors[0] != (ghfake.BypassActor{ActorID: 1, ActorType: "Integration", BypassMode: "always"}) {
+		t.Errorf("default bypass = %+v", repo.Rulesets[0].BypassActors)
+	}
+	if len(repo.Rulesets[0].Rules) != 1 {
+		t.Errorf("update dropped rules: %+v", repo.Rulesets[0].Rules)
+	}
+}
 
 func TestForge_EnsureRepoSetup(t *testing.T) {
 	srv, f := newTestForge(t)


### PR DESCRIPTION
- treat 422 'Repository rule violations found' as PushDeniedError so the PR is ejected with an actionable comment instead of retrying forever
- EnsureRepoSetup adds the App as bypass actor to existing repo-level branch rulesets; warns for org-level ones

Hit on Mic92/niks3#467 where the `default` ruleset (require PR) rejected the queue's fast-forward.