### PR TITLE
Add multi-arch container image (ghcr.io)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,53 @@
+name: Build Docker Image
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Create Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha,format=short
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.thalheim.io
+            extra-trusted-public-keys = cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc=
+      - name: Build Docker image
+        run: |
+          nix build .#gitea-mq-docker --print-build-logs
+      - name: Push images
+        env:
+          REGCTL_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -xve
+          PATH="$(nix build --inputs-from . nixpkgs#regctl --print-out-paths --no-link)/bin:$PATH"
+          regctl registry login "$REGISTRY" -u "${{ github.actor }}" --pass-stdin <<< "$REGCTL_PASSWORD"
+          regctl image import "ocidir://local:gitea-mq" ./result
+          for tag in $(echo '${{ steps.meta.outputs.tags }}' | tr ' ' '\n'); do
+            regctl image copy "ocidir://local:gitea-mq" "$tag"
+          done

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787111413,
-        "narHash": "sha256-sFosWtq21eHGJRnTc/hvf4M1obRgLEUMNm/IzllkHMA=",
+        "lastModified": 1787364730,
+        "narHash": "sha256-NcYt9QJfpJiF1lAyN8BDPB4EeScbPU+EwQqPiBElrpU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afe3d8ac4395617bdcdac9f188ac8717a062e014",
+        "rev": "a831408e6378bc02ebf8cc09b52c96ca86f6bab4",
         "type": "github"
       },
       "original": {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  pkgs,
+  gitea-mq,
+  imageName ? "${gitea-mq.pname}:latest",
+}:
+let
+  allPlatforms = {
+    "x86_64-linux" = {
+      GOOS = "linux";
+      GOARCH = "amd64";
+    };
+    "aarch64-linux" = {
+      GOOS = "linux";
+      GOARCH = "arm64";
+    };
+  };
+  platforms = lib.mapAttrs (
+    crossSystem:
+    { GOOS, GOARCH }:
+    let
+      inherit (pkgs.stdenv.hostPlatform) system;
+      crossPkgs =
+        if system == crossSystem then pkgs else (import pkgs.path { inherit system crossSystem; });
+    in
+    crossPkgs.dockerTools.buildLayeredImage {
+      name = gitea-mq.pname;
+      tag = "${gitea-mq.version}-${crossSystem}";
+      # The per-arch tarball is an intermediate that regctl decompresses
+      # immediately; pigz has been observed to segfault on busy CI runners.
+      # The final multi-arch image is compressed by regctl on export.
+      compressor = "none";
+      contents = [
+        # Cross-compile with the native (cached) Go toolchain instead of
+        # pulling in a full cross stdenv for Go.
+        (gitea-mq.overrideAttrs (old: {
+          env = (old.env or { }) // {
+            inherit GOOS GOARCH;
+            CGO_ENABLED = 0;
+          };
+          # Tests need a native postgres/gitea and can't run foreign binaries.
+          doCheck = false;
+          postInstall = (old.postInstall or "") + ''
+            if [ -d $out/bin/${GOOS}_${GOARCH} ]; then
+              mv $out/bin/${GOOS}_${GOARCH}/* $out/bin/
+              rmdir $out/bin/${GOOS}_${GOARCH}
+            fi
+          '';
+        }))
+        # Merge branches are built by shelling out to git.
+        crossPkgs.gitMinimal
+      ]
+      ++ (with crossPkgs.pkgsStatic; [
+        busybox
+        busybox-sandbox-shell
+        cacert
+      ]);
+      config = {
+        Entrypoint = [ "/bin/gitea-mq" ];
+        Env = [
+          "XDG_CACHE_HOME=/var/cache"
+          "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+        ];
+        Volumes = {
+          "/var/cache/gitea-mq" = { };
+        };
+        ExposedPorts = {
+          "8080" = { };
+        };
+      };
+    }
+  ) allPlatforms;
+in
+pkgs.stdenvNoCC.mkDerivation {
+  name = "${gitea-mq.pname}-docker";
+  inherit (gitea-mq) version;
+  phases = [ "installPhase" ];
+  src = pkgs.linkFarm "images" (lib.mapAttrsToList (name: path: { inherit name path; }) platforms);
+  nativeBuildInputs = [ pkgs.regctl ];
+  installPhase = ''
+    set -xve
+    image_refs=()
+    for platform in $src/*; do
+      ref_url="ocidir://images:$(basename $platform)"
+      image_refs+=("--ref" "$ref_url")
+      regctl image import "$ref_url" "$platform"
+    done
+    regctl index create "ocidir://images:latest" "''${image_refs[@]}"
+    regctl image export "ocidir://images:latest" --name "${imageName}" > $out
+  '';
+}


### PR DESCRIPTION
Same setup as niks3: `nix build .#gitea-mq-docker` builds an amd64+arm64 OCI index; CI pushes to ghcr.io on main and v* tags. Tested locally against postgres:17.