### PR TITLE
flake: expose gitea-mq-docker package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,9 @@
           inherit gitea-mq;
           default = gitea-mq;
         }
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          gitea-mq-docker = pkgs.callPackage ./nix/docker.nix { inherit gitea-mq; };
+        }
       );
 
       devShells = eachSystem (


### PR DESCRIPTION
flake.nix hunk was missing from #92; CI failed with 'does not provide attribute gitea-mq-docker'.