### PR TITLE
Release infrastructure + README container docs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes

--- a/README.md
+++ b/README.md
@@ -234,6 +234,41 @@ Repo and PR pages live under `/repo/{forge}/{owner}/{name}` (e.g.
 `/repo/github/org/app/pr/42`). Paths without the forge segment resolve as Gitea
 for compatibility with links posted by older versions.
 
+## Container
+
+A multi-arch (amd64/arm64) image is published to
+`ghcr.io/mic92/gitea-mq` (`:main`, `:vX.Y.Z`). It contains gitea-mq, git and
+CA certificates; configuration is via the environment variables above. It needs
+a PostgreSQL database; the bare-clone cache lives in `/var/cache/gitea-mq`.
+
+```yaml
+services:
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: gitea-mq
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: gitea-mq
+    volumes: [db:/var/lib/postgresql/data]
+  gitea-mq:
+    image: ghcr.io/mic92/gitea-mq:main
+    ports: ["8080:8080"]
+    environment:
+      GITEA_MQ_DATABASE_URL: postgres://gitea-mq:changeme@db/gitea-mq?sslmode=disable
+      GITEA_MQ_EXTERNAL_URL: https://mq.example.com
+      GITEA_MQ_GITEA_URL: https://gitea.example.com
+      GITEA_MQ_GITEA_TOKEN: ...
+      GITEA_MQ_WEBHOOK_SECRET: ...
+      GITEA_MQ_TOPIC: merge-queue
+    volumes: [cache:/var/cache/gitea-mq]
+volumes:
+  db:
+  cache:
+```
+
+Build it yourself with `nix build .#gitea-mq-docker` (produces an OCI archive;
+load with `regctl image import` or `skopeo copy oci-archive:result docker-daemon:gitea-mq:latest`).
+
 ## NixOS module
 
 ```nix

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd "$SCRIPT_DIR/.."
+
+version="${1:-}"
+if [[ -z $version ]]; then
+  echo "USAGE: $0 version" >&2
+  exit 1
+fi
+
+# Strip "v" prefix if provided
+version="${version#v}"
+
+if [[ "$(git symbolic-ref --short HEAD)" != "main" ]]; then
+  echo "must be on main branch" >&2
+  exit 1
+fi
+
+waitForPr() {
+  local pr=$1
+  while true; do
+    if gh pr view "$pr" | grep -q 'MERGED'; then
+      break
+    fi
+    echo "Waiting for PR to be merged..."
+    sleep 5
+  done
+}
+
+# ensure we are up-to-date
+uncommitted_changes=$(git diff --compact-summary)
+if [[ -n $uncommitted_changes ]]; then
+  echo -e "There are uncommitted changes, exiting:\n${uncommitted_changes}" >&2
+  exit 1
+fi
+git pull git@github.com:Mic92/gitea-mq main
+unpushed_commits=$(git log --format=oneline origin/main..main)
+if [[ $unpushed_commits != "" ]]; then
+  echo -e "\nThere are unpushed changes, exiting:\n$unpushed_commits" >&2
+  exit 1
+fi
+# make sure tag does not exist
+if git tag -l | grep -q "^v${version}\$"; then
+  echo "Tag v${version} already exists, exiting" >&2
+  exit 1
+fi
+
+# Update version in nix package file
+sed -i -e "s!version = \".*\";!version = \"${version}\";!" nix/package.nix
+
+git add nix/package.nix
+git branch -D "release-${version}" || true
+git checkout -b "release-${version}"
+git commit -m "bump version ${version}"
+git push origin "release-${version}"
+pr_url=$(gh pr create \
+  --base main \
+  --head "release-${version}" \
+  --title "Release ${version}" \
+  --body "Release ${version} of gitea-mq")
+
+# Extract PR number from URL
+pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
+
+# Enable auto-merge with specific merge method and delete branch
+gh pr merge "$pr_number" --auto --merge --delete-branch
+git checkout main
+
+waitForPr "release-${version}"
+git pull git@github.com:Mic92/gitea-mq main
+git tag "v${version}"
+git push origin "v${version}"


### PR DESCRIPTION
- README: Container section with compose example
- bin/create-release.sh: bump version, PR via merge queue, push tag
- release.yml: GitHub release with generated notes on v* tags (docker-image.yml already builds :vX.Y.Z)