### PR TITLE
batch: land up-to-date heads via fast-forward instead of forge merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Trade-offs and prerequisites:
     whitelist*. If you forget, every PR in the batch is removed with a comment
     naming the branch and the user to add.
 - Batched PRs land as **merge commits** regardless of the repo's configured
-  merge style. Repos that mandate squash/rebase should leave `BATCH_MAX=1`.
+  merge style. A single PR that already contains the target tip is landed
+  by fast-forwarding to its head (no merge commit, no extra CI run). Repos that mandate squash/rebase should leave `BATCH_MAX=1`.
 - A semantic conflict between two PRs that bisection puts in different halves
   can land both (each half passes alone). This matches bors-ng; keep
   `BATCH_MAX` modest if it bothers you.

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -50,6 +50,9 @@ type Engine struct {
 	CheckTimeout   time.Duration
 	FallbackChecks []string
 	MergeLabel     string
+	// SkipIfUpToDate lands a single up-to-date PR by fast-forwarding to its
+	// head instead of building a batch branch.
+	SkipIfUpToDate bool
 
 	// MergedPoll controls ensureMergedOrClose. Defaults: 200ms × 50 = 10s.
 	MergedPollInterval time.Duration
@@ -161,7 +164,10 @@ func (e *Engine) Build(ctx context.Context, b *pg.Batch) error {
 	for i := range entries {
 		heads[i] = entries[i].PrHeadSha
 	}
-	tip, steps, err := e.stack(ctx, b.TargetBranch, heads, branch)
+	tip, steps := e.headIfUpToDate(ctx, b.TargetBranch, heads)
+	if tip == "" {
+		tip, steps, err = e.stack(ctx, b.TargetBranch, heads, branch)
+	}
 	if err != nil {
 		// Whole-operation failure (clone/push). Row stays forming;
 		// FormAndBuild retries on the next tick.
@@ -421,6 +427,23 @@ func (e *Engine) ReconcileLive(ctx context.Context) error {
 		unlock()
 	}
 	return nil
+}
+
+// headIfUpToDate returns the lone head as tip when it already contains base;
+// empty tip means a batch branch must be built.
+func (e *Engine) headIfUpToDate(ctx context.Context, base string, heads []string) (string, []forge.MergeStep) {
+	if !e.SkipIfUpToDate || len(heads) != 1 {
+		return "", nil
+	}
+	up, err := e.Forge.IsUpToDate(ctx, e.Owner, e.Repo, base, heads[0])
+	if err != nil {
+		slog.Warn("up-to-date check failed, building batch branch", "sha", heads[0], "error", err)
+		return "", nil
+	}
+	if !up {
+		return "", nil
+	}
+	return heads[0], []forge.MergeStep{{}}
 }
 
 // stack builds the batch branch, preferring a forge-native MergeStacker when

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -300,6 +300,46 @@ func TestHandlePass_ContextCanceledAfterFastForward(t *testing.T) {
 	}
 }
 
+// A single up-to-date PR is landed by fast-forwarding to its head; no batch
+// branch is built.
+func TestBuild_UpToDateSingletonLandsHead(t *testing.T) {
+	e, f, svc, ctx := setup(t, 10)
+	e.SkipIfUpToDate = true
+	f.merged[10] = true
+	f.FastForwardFn = func(_ context.Context, _, _, _, sha string) error {
+		f.target = sha
+		return nil
+	}
+	f.IsUpToDateFn = func(_ context.Context, _, _, base, head string) (bool, error) {
+		return base == "main" && head == "sha10", nil
+	}
+	f.GetRequiredChecksFn = func(context.Context, string, string, string) ([]string, error) {
+		return []string{"ci"}, nil
+	}
+
+	b, err := e.FormAndBuild(ctx, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.BranchSha.String != "sha10" {
+		t.Fatalf("branch sha = %q, want PR head", b.BranchSha.String)
+	}
+	if n := len(f.CallsTo("CreateMergeBranch")); n != 0 {
+		t.Fatalf("CreateMergeBranch called %d times", n)
+	}
+
+	rep, _ := svc.GetEntry(ctx, e.RepoID, 10)
+	if err := e.HandleCheck(ctx, rep, "ci", pg.CheckStateSuccess, ""); err != nil {
+		t.Fatal(err)
+	}
+	if f.target != "sha10" {
+		t.Fatalf("target = %q, want sha10", f.target)
+	}
+	if b, _ := svc.GetLiveBatch(ctx, e.RepoID, "main"); b != nil {
+		t.Fatalf("batch still live: %+v", b)
+	}
+}
+
 func TestHandleCheck_EvaluatesAndDispatches(t *testing.T) {
 	e, f, svc, ctx := setup(t, 10, 20)
 	f.merged[10], f.merged[20] = true, true

--- a/internal/poller/label_test.go
+++ b/internal/poller/label_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mic92/gitea-mq/internal/batch"
 	"github.com/Mic92/gitea-mq/internal/forge"
 	"github.com/Mic92/gitea-mq/internal/poller"
 	"github.com/Mic92/gitea-mq/internal/queue"
@@ -133,6 +134,60 @@ func TestFinalizeLabeledStackMerge(t *testing.T) {
 	merges := mock.CallsTo("MergePR")
 	if len(merges) != 1 || merges[0].Args[2].(int64) != 2 {
 		t.Fatalf("MergePR calls = %+v", merges)
+	}
+}
+
+// Regression: an up-to-date labeled stack head must be landed by gitea-mq
+// (fast-forward), not handed to the forge's merge API which re-checks every
+// stack member's own rules.
+func TestLabeledStackUpToDateLandsViaFastForward(t *testing.T) {
+	deps, mock, svc, ctx, repoID := setupLabelTest(t)
+	deps.SkipQueueIfUpToDate = true
+	deps.Batch = &batch.Engine{
+		Forge: mock, Queue: svc, Owner: "org", Repo: "app", RepoID: repoID,
+		SkipIfUpToDate: true, MergedPollInterval: 1, MergedPollAttempts: 1,
+	}
+	mock.ListOpenPRsFn = func(context.Context, string, string) ([]forge.PR, error) {
+		return []forge.PR{
+			{Number: 1, State: "open", HeadBranch: "b1", HeadSHA: "sha1", BaseBranch: "main"},
+			{Number: 2, State: "open", HeadBranch: "b2", HeadSHA: "sha2", BaseBranch: "b1", Labels: []string{"merge-queue"}},
+		}, nil
+	}
+	mock.ResolveStackFn = func(context.Context, string, string, int64) (*forge.Stack, error) {
+		return &forge.Stack{BaseBranch: "main", PRs: []forge.StackPR{
+			{Number: 1, HeadSHA: "sha1"}, {Number: 2, HeadSHA: "sha2"},
+		}}, nil
+	}
+	mock.IsUpToDateFn = func(_ context.Context, _, _, base, head string) (bool, error) {
+		return base == "main" && head == "sha2", nil
+	}
+	mock.GetRequiredChecksFn = func(context.Context, string, string, string) ([]string, error) {
+		return []string{"ci"}, nil
+	}
+	mock.GetCheckStatesFn = func(_ context.Context, _, _, sha string) (map[string]forge.Check, error) {
+		return map[string]forge.Check{"ci": {State: pg.CheckStateSuccess}}, nil
+	}
+	var ffTo string
+	mock.FastForwardFn = func(_ context.Context, _, _, branch, sha string) error {
+		if branch != "main" {
+			t.Errorf("fast-forward branch = %q", branch)
+		}
+		ffTo = sha
+		return nil
+	}
+
+	if res, err := poller.PollOnce(ctx, deps); err != nil || len(res.Errors) > 0 {
+		t.Fatalf("PollOnce: %v %v", err, res)
+	}
+
+	if ffTo != "sha2" {
+		t.Fatalf("main fast-forwarded to %q, want sha2", ffTo)
+	}
+	if n := len(mock.CallsTo("MergePR")); n != 0 {
+		t.Fatalf("MergePR called %d times; forge must not be asked to merge", n)
+	}
+	if e, _ := svc.GetEntry(ctx, repoID, 2); e != nil {
+		t.Fatalf("entry should be landed and removed: %+v", e)
 	}
 }
 

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -418,9 +418,9 @@ func hintStackedPRs(ctx context.Context, deps *Deps, openPRs []forge.PR) {
 	}
 }
 
-// finalizeLabeledMerge completes label-triggered entries that passed the
-// queue: the forge has no automerge armed for them, so gitea-mq flips the
-// remaining stack heads green and performs the (stack-aware) merge itself.
+// finalizeLabeledMerge merges label-triggered entries in "success" via the
+// forge, since no automerge is armed for them. Legacy (non-batch) path only;
+// the batch engine lands entries itself.
 func finalizeLabeledMerge(ctx context.Context, deps *Deps, result *PollResult, entry *pg.QueueEntry, pr *forge.PR) {
 	if deps.MergeLabel == "" || entry.State != pg.EntryStateSuccess || pr == nil || pr.Merged || !pr.HasLabel(deps.MergeLabel) {
 		return
@@ -654,14 +654,15 @@ func startQueuedHeads(ctx context.Context, deps *Deps, result *PollResult) {
 			continue
 		}
 
-		if deps.SkipQueueIfUpToDate && tryFastForwardSuccess(ctx, deps, result, head) {
-			continue
-		}
-
+		// The batch engine handles up-to-date heads itself (SkipIfUpToDate).
 		if deps.Batch.Enabled() {
 			if _, err := deps.Batch.FormAndBuild(ctx, entry.TargetBranch); err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("form batch for %s: %w", entry.TargetBranch, err))
 			}
+			continue
+		}
+
+		if deps.SkipQueueIfUpToDate && tryFastForwardSuccess(ctx, deps, result, head) {
 			continue
 		}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -120,6 +120,7 @@ func (r *RepoRegistry) Add(ctx context.Context, ref forge.RepoRef) error {
 			CheckTimeout:   r.deps.CheckTimeout,
 			FallbackChecks: r.deps.FallbackChecks,
 			MergeLabel:     r.deps.MergeLabel,
+			SkipIfUpToDate: r.deps.SkipQueueIfUpToDate,
 			Advance:        triggerPoll,
 		}
 	}


### PR DESCRIPTION
In batch mode an up-to-date head was still promoted to "success" and,
for labeled PRs, merged via GitHub's merge-async. That re-checks every
stack member's own required checks and fails asynchronously, so a stuck
check on a lower PR left the head in success until SuccessTimeout
removed it (Mic92/nixbot#179).

Let the batch engine handle this case: a lone head containing the
target tip becomes the batch SHA and is landed by fast-forward like any
other batch, making gitea-mq the only party deciding mergeability.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>