### PR TITLE
Add a base path to templates

### DIFF
--- a/cmd/gitea-mq/main.go
+++ b/cmd/gitea-mq/main.go
@@ -184,6 +184,7 @@ func run() error {
 		Forges:          forges,
 		FallbackChecks:  cfg.RequiredChecks,
 		RefreshInterval: int(cfg.RefreshInterval.Seconds()),
+		BasePath:        cfg.BasePath,
 	}
 	dashMux := web.NewMux(webDeps)
 	// Mount dashboard routes — the web mux handles /, /repo/, /static/.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,6 +21,7 @@ type Config struct {
 	ListenAddr          string
 	WebhookPath         string
 	ExternalURL         string
+	BasePath            string
 	PollInterval        time.Duration
 	IdlePollInterval    time.Duration
 	CheckTimeout        time.Duration
@@ -93,6 +95,12 @@ func Load() (*Config, error) {
 	cfg.Github, err = loadGithub(&missing)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.ExternalURL != "" {
+		if u, err := url.Parse(cfg.ExternalURL); err == nil {
+			cfg.BasePath = strings.TrimRight(u.Path, "/")
+		}
 	}
 
 	if len(missing) > 0 {

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -103,6 +103,7 @@ type RepoOverview struct {
 
 // OverviewData is the template data for the overview page.
 type OverviewData struct {
+	BasePath        string
 	Repos           []RepoOverview
 	RefreshInterval int // seconds
 }
@@ -129,6 +130,7 @@ type RepoDetailBatch struct {
 // RepoDetailData is the template data for the repo detail page.
 type RepoDetailData struct {
 	Forge           forge.Kind
+	BasePath        string
 	Owner           string
 	Name            string
 	RepoURL         string // link to the repo on the forge
@@ -140,6 +142,7 @@ type RepoDetailData struct {
 // PRDetailData is the template data for the PR detail page.
 type PRDetailData struct {
 	Forge           forge.Kind
+	BasePath        string
 	Owner           string
 	Name            string
 	PrNumber        int64
@@ -172,6 +175,7 @@ type Deps struct {
 	Forges          *forge.Set
 	FallbackChecks  []string // from GITEA_MQ_REQUIRED_CHECKS
 	RefreshInterval int      // seconds
+	BasePath        string
 }
 
 // NewMux creates an http.ServeMux with the dashboard routes registered.
@@ -206,6 +210,7 @@ func overviewHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		data := OverviewData{
+			BasePath:        deps.BasePath,
 			RefreshInterval: deps.RefreshInterval,
 		}
 
@@ -307,6 +312,7 @@ func serveRepoDetail(w http.ResponseWriter, r *http.Request, deps *Deps, ref for
 
 	data := RepoDetailData{
 		Forge:           ref.Forge,
+		BasePath:        deps.BasePath,
 		Owner:           owner,
 		Name:            name,
 		RefreshInterval: deps.RefreshInterval,
@@ -379,6 +385,7 @@ func servePRDetail(w http.ResponseWriter, r *http.Request, deps *Deps, ref forge
 
 	data := PRDetailData{
 		Forge:           ref.Forge,
+		BasePath:        deps.BasePath,
 		Owner:           owner,
 		Name:            name,
 		PrNumber:        prNumber,

--- a/internal/web/templates/overview.html
+++ b/internal/web/templates/overview.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="refresh" content="{{.RefreshInterval}}">
     <title>gitea-mq – Merge Queue</title>
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="{{.BasePath}}/static/style.css">
 </head>
 <body>
     <nav class="breadcrumb">gitea-mq</nav>
@@ -16,7 +16,7 @@
     <div class="repo-list">
         {{range .Repos}}
         <div class="repo-item">
-            <a href="/repo/{{.Forge}}/{{.Owner}}/{{.Name}}"><span class="forge-badge forge-{{.Forge}}">{{.Forge}}</span> {{.Owner}}/{{.Name}}</a>
+            <a href="{{$.BasePath}}/repo/{{.Forge}}/{{.Owner}}/{{.Name}}"><span class="forge-badge forge-{{.Forge}}">{{.Forge}}</span> {{.Owner}}/{{.Name}}</a>
             <span class="badge {{if eq .QueueSize 0}}badge-empty{{else}}badge-active{{end}}">{{.QueueSize}}</span>
         </div>
         {{end}}

--- a/internal/web/templates/pr.html
+++ b/internal/web/templates/pr.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="refresh" content="{{.RefreshInterval}}">
     <title>PR #{{.PrNumber}} – {{.Owner}}/{{.Name}} – gitea-mq</title>
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="{{.BasePath}}/static/style.css">
 </head>
 <body>
-    <nav class="breadcrumb"><a href="/">gitea-mq</a> › <a href="/repo/{{.Forge}}/{{.Owner}}/{{.Name}}">{{.Forge}}:{{.Owner}}/{{.Name}}</a> › PR #{{.PrNumber}}</nav>
+    <nav class="breadcrumb"><a href="{{.BasePath}}/">gitea-mq</a> › <a href="{{.BasePath}}/repo/{{.Forge}}/{{.Owner}}/{{.Name}}">{{.Forge}}:{{.Owner}}/{{.Name}}</a> › PR #{{.PrNumber}}</nav>
 
     {{if not .InQueue}}
     <h1>PR #{{.PrNumber}}</h1>
@@ -25,7 +25,7 @@
                 {{if .MergeBranchURL}}<tr><th>Merge Branch</th><td><a href="{{.MergeBranchURL}}">view on {{forgeName .Forge}} ↗</a></td></tr>{{end}}
                 {{if .BatchID}}
                 <tr><th>Batch</th><td>#{{.BatchID}} · <span class="bucket bucket-{{.BatchBucket}}">{{.BatchBucket}}</span>
-                    {{if .BatchPRs}}· with {{range $i, $n := .BatchPRs}}{{if $i}}, {{end}}<a href="/repo/{{$.Forge}}/{{$.Owner}}/{{$.Name}}/pr/{{$n}}">#{{$n}}</a>{{end}}{{end}}
+                    {{if .BatchPRs}}· with {{range $i, $n := .BatchPRs}}{{if $i}}, {{end}}<a href="{{$.BasePath}}/repo/{{$.Forge}}/{{$.Owner}}/{{$.Name}}/pr/{{$n}}">#{{$n}}</a>{{end}}{{end}}
                 </td></tr>
                 {{end}}
             </tbody>

--- a/internal/web/templates/repo.html
+++ b/internal/web/templates/repo.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="refresh" content="{{.RefreshInterval}}">
     <title>{{.Owner}}/{{.Name}} – gitea-mq</title>
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="{{.BasePath}}/static/style.css">
 </head>
 <body>
-    <nav class="breadcrumb"><a href="/">gitea-mq</a> › {{.Forge}}:{{.Owner}}/{{.Name}}</nav>
+    <nav class="breadcrumb"><a href="{{.BasePath}}/">gitea-mq</a> › {{.Forge}}:{{.Owner}}/{{.Name}}</nav>
     <h1>🚦 {{if .RepoURL}}<a href="{{.RepoURL}}">{{.Owner}}/{{.Name}}</a>{{else}}{{.Owner}}/{{.Name}}{{end}}</h1>
     <p class="subtitle">Merge Queue</p>
 
@@ -35,7 +35,7 @@
                 {{range $i, $e := .Entries}}
                 <tr>
                     <td>{{inc $i}}</td>
-                    <td><a href="/repo/{{$.Forge}}/{{$.Owner}}/{{$.Name}}/pr/{{$e.PrNumber}}">PR #{{$e.PrNumber}}</a></td>
+                    <td><a href="{{$.BasePath}}/repo/{{$.Forge}}/{{$.Owner}}/{{$.Name}}/pr/{{$e.PrNumber}}">PR #{{$e.PrNumber}}</a></td>
                     <td>{{$e.TargetBranch}}</td>
                     <td><span class="state state-{{$e.State}}">{{$e.State}}</span>{{if $e.BatchBucket}} <span class="bucket bucket-{{$e.BatchBucket}}">{{$e.BatchBucket}}</span>{{end}}</td>
                 </tr>


### PR DESCRIPTION
I have a domain with `/gitea-mq` hosted underneath it. I've been running a patch like this for months, and just rebased it on main today.